### PR TITLE
Sdfsection

### DIFF
--- a/Xtext/trans/generate/enum-rule.str
+++ b/Xtext/trans/generate/enum-rule.str
@@ -15,7 +15,7 @@ rules
 	// 	]
 		
 	gen-rule:
-		EnumRule(name, enum-literals) -> LexicalSyntax(<map(gen-enum-literal(|name))> enum-literals)
+		EnumRule(name, enum-literals) -> SDFSection(LexicalSyntax(<map(gen-enum-literal(|name))> enum-literals))
 	
 	// gen-enum-literal:
 	// 	EnumLiteral(name) -> $["[name]"]

--- a/Xtext/trans/generate/terminal-rule.str
+++ b/Xtext/trans/generate/terminal-rule.str
@@ -16,10 +16,10 @@ rules
 	
 	gen-rule:
 		TerminalRule(Returns(terminal-name, _), terminal-token-element) ->
-			LexicalSyntax([SdfProduction(SortDef(terminal-name), Rhs([<gen-terminal-token-element ; innermost(post-process-terminal-rule); remove-parenthetical> terminal-token-element]), NoAttrs())])
+			SDFSection(LexicalSyntax([SdfProduction(SortDef(terminal-name), Rhs([syntax-rules]), NoAttrs())]))
 			where
-				<debug> <remove-parenthetical> <gen-terminal-token-element ; innermost(post-process-terminal-rule)> terminal-token-element
-				
+				syntax-rules := <gen-terminal-token-element ; innermost(post-process-terminal-rule); remove-parenthetical> terminal-token-element
+	
 	post-process-terminal-rule:
 		CharClass(Simple(Present(Alt(x, y)))) -> Alt(x, y)
 	


### PR DESCRIPTION
Add SDFSection around LexicalSyntax for both TerminalRule and EnumRule. This fixes a bug that prevents generating SDF for complete Xtext files (containing parser rules, enum rules, and terminal rules) such as:

```
grammar org.xtext.example.SecretCompartments 
   with org.eclipse.xtext.common.Terminals

generate secrets "http://www.eclipse.org/secretcompartment"

Command :
  name=ID code=ID;

enum ChangeKind :
  ADD = '+'
;

terminal ID :
  'a'..'z'
;
```
