### PR TITLE
Cross reference

### DIFF
--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -68,11 +68,10 @@ rules
 	gen-unordered-groups(|name, attr):
 		UnorderedGroup(groups) -> <flatten-list> [group | extra_rules]
 		where
-			permutations := <gen-permutations(|groups)>;
-
+			permutations     := <gen-permutations(|groups)>;
 			groups_generated := <map(gen-groups(|name, attr))> permutations;
-			group			:= <try(concat)> <map(extract-outputs)> groups_generated;
-			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> groups_generated
+			group			 := <try(concat)> <map(extract-outputs)> groups_generated;
+			extra_rules		 := <try(concat)> <map(extract-nested-outputs)> groups_generated
 				
 	gen-groups(|name, attr):
 		groups -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
@@ -136,7 +135,10 @@ rules
 		Keyword(word) -> (Lit(<double-quote> word),[])
 		// where
 		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
-			
+	
+	gen-assignable-terminal(|name, attr):
+		CrossReference(TypeRef(_, _)) -> (Sort("ID"), [])
+	
 	gen-assignable-terminal(|name, attr):
 		AssignableAlternatives(alternatives) -> (output, nested)
 		where

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -70,8 +70,8 @@ rules
 		where
 			permutations     := <gen-permutations(|groups)>;
 			groups_generated := <map(gen-groups(|name, attr))> permutations;
-			group			 := <try(concat)> <map(extract-outputs)> groups_generated;
-			extra_rules		 := <try(concat)> <map(extract-nested-outputs)> groups_generated
+			group            := <try(concat)> <map(extract-outputs)> groups_generated;
+			extra_rules      := <try(concat)> <map(extract-nested-outputs)> groups_generated
 				
 	gen-groups(|name, attr):
 		groups -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
@@ -137,7 +137,10 @@ rules
 		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
 	
 	gen-assignable-terminal(|name, attr):
-		CrossReference(TypeRef(_, _)) -> (Sort("ID"), [])
+		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
+		
+	gen-assignable-terminal(|name, attr):
+		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
 	
 	gen-assignable-terminal(|name, attr):
 		AssignableAlternatives(alternatives) -> (output, nested)
@@ -177,9 +180,6 @@ rules
 	// 	with
 	// 		gen-assignable-terminal := <gen-assignable-terminal> assignable-terminal;
 	// 		gen-cardinality			:= <gen-cardinality> cardinality-opt
-	
-	gen-abstract-token:
-		AssignmentAbstractToken(_, feature, type, assignable-terminal, cardinality-opt) -> <gen-assignable-terminal> assignable-terminal
 	
 //	gen-abstract-token:
 	//	AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> $[[gen-abstract-terminal] [gen-cardinality]]


### PR DESCRIPTION
By default, transform a cross-reference into a sort ID. If the optional CrossReferenceTerminal is given, use that instead as name of the sort. For example:

Xtext:

```
ClassType : classref=[Class];
```

Resulting SDF:

```
ClassType = classref:ID
```

Xtext:

```
ClassType : classref=[Class|FancyTerminalRule];
```

Resulting SDF:

```
ClassType = classref:FancyTerminalRule
```
