### PR TITLE
Add quotes around string literals in enum rules

### DIFF
--- a/Xtext/trans/generate/enum-rule.str
+++ b/Xtext/trans/generate/enum-rule.str
@@ -21,10 +21,10 @@ rules
 	// 	EnumLiteral(name) -> $["[name]"]
 	
 	gen-enum-literal(|name):
-		EnumLiteral(value) -> SdfProduction(SortDef(name), Rhs([Lit(value)]), NoAttrs())
+		EnumLiteral(value) -> SdfProduction(SortDef(name), Rhs([Lit(<double-quote> value)]), NoAttrs())
 	
 	gen-enum-literal(|name):
-		EnumLiteral(_, value) -> SdfProduction(SortDef(name), Rhs([Lit(value)]), NoAttrs())
+		EnumLiteral(_, value) -> SdfProduction(SortDef(name), Rhs([Lit(<double-quote> value)]), NoAttrs())
 	
 	// prefix(|name):
 	// 	result -> $[[name] = [result]]


### PR DESCRIPTION
Small PR that adds quotes around strings in enum literals, per @JeffGoderie's request. I initially intended to translate EnumRule's to context-free syntax (instead of lexical syntax), but I was unable to create a use case in which context-free syntax is necessary.
