### PR TITLE
Nabl

### DIFF
--- a/Xtext/editor/Xtext-Menus.esv
+++ b/Xtext/editor/Xtext-Menus.esv
@@ -34,3 +34,4 @@ menus
     
     action: "Generate SDF (ATerm)"   = gen-sdf
 	action: "Generate SDF"           = gen-sdf-file
+	action: "Generate NaBL"          = gen-nabl

--- a/Xtext/nabl/src-gen/check/NameBindingLanguage-chk.str
+++ b/Xtext/nabl/src-gen/check/NameBindingLanguage-chk.str
@@ -1,0 +1,801 @@
+module nabl/src-gen/check/NameBindingLanguage-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/NameBindingLanguage-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Layout-sig
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Signatures-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Formulas-sig
+  nabl/src-gen/signatures/formulas/Propositions-sig
+  nabl/src-gen/signatures/core/Modules-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/core/Properties-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/check/common/Layout-chk
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/terms/Signatures-chk
+  nabl/src-gen/check/terms/Terms-chk
+  nabl/src-gen/check/formulas/Formulas-chk
+  nabl/src-gen/check/formulas/Propositions-chk
+  nabl/src-gen/check/core/Modules-chk
+  nabl/src-gen/check/core/Namespaces-chk
+  nabl/src-gen/check/core/Properties-chk
+  nabl/src-gen/check/terms/Vars-chk
+
+
+strategies
+  check-SDF-start-symbols =
+    check-Start
+
+
+strategies
+  check-example =
+    check-Start
+
+  check-Start :
+    t1__ -> <id>
+    where not(is-Start-with-constructor)
+    where <(check-Module <+ error-Module)> t1__
+
+  is-Start-with-constructor =
+    fail
+
+  check-Start :
+    amb([h|hs]) -> <check-Start> h
+
+  error-Start =
+    debug(!"Unexpected constructor. Expected constructor from sort Start instead. ")
+
+
+strategies
+  check-example =
+    check-RestrictedNamespaceRef
+
+  check-example =
+    check-Restriction
+
+  check-RestrictedNamespaceRef :
+    Restricted(t1__, t2__) -> <id>
+    with <map(check-Restriction <+ error-Restriction)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+
+  is-RestrictedNamespaceRef-with-constructor =
+    ?Restricted(_, _)
+
+  check-Restriction :
+    Imported() -> <id>
+
+  is-Restriction-with-constructor =
+    ?Imported()
+
+  is-RestrictedNamespaceRef-with-constructor =
+    fail
+
+  is-Restriction-with-constructor =
+    fail
+
+  check-RestrictedNamespaceRef :
+    amb([h|hs]) -> <check-RestrictedNamespaceRef> h
+
+  check-Restriction :
+    amb([h|hs]) -> <check-Restriction> h
+
+  error-RestrictedNamespaceRef =
+    debug(!"Unexpected constructor. Expected constructor from sort RestrictedNamespaceRef instead. ")
+
+  error-Restriction =
+    debug(!"Unexpected constructor. Expected constructor from sort Restriction instead. ")
+
+
+strategies
+  check-example =
+    check-PropertyDef
+
+  check-example =
+    check-QualityRef
+
+  check-example =
+    check-PropertyTerm
+
+  check-example =
+    check-PropertyPattern
+
+  check-example =
+    check-PropFilter
+
+  check-PropertyDef :
+    QualityDef(t1__, t2__) -> <id>
+    with <(check-PropertyID <+ error-PropertyID)> t1__
+    with <map(check-NamespaceRef <+ error-NamespaceRef)> t2__
+
+  is-PropertyDef-with-constructor =
+    ?QualityDef(_, _)
+
+  check-QualityRef :
+    QualityRef(t1__) -> <id>
+    with <(check-PropertyID <+ error-PropertyID)> t1__
+
+  is-QualityRef-with-constructor =
+    ?QualityRef(_)
+
+  check-PropertyTerm :
+    PropertyTerm(t1__, t2__) -> <id>
+    with <(check-PropertyRef <+ error-PropertyRef)> t1__
+    with <(check-Term <+ error-Term)> t2__
+
+  is-PropertyTerm-with-constructor =
+    ?PropertyTerm(_, _)
+
+  check-PropertyTerm :
+    QualityTerm(t1__) -> <id>
+    with <(check-QualityRef <+ error-QualityRef)> t1__
+
+  is-PropertyTerm-with-constructor =
+    ?QualityTerm(_)
+
+  check-PropertyPattern :
+    PropertyPattern(t1__, t2__, t3__) -> <id>
+    with <(check-PropFilter <+ error-PropFilter)> t1__
+    with <(check-PropertyRef <+ error-PropertyRef)> t2__
+    with <(check-Term <+ error-Term)> t3__
+
+  is-PropertyPattern-with-constructor =
+    ?PropertyPattern(_, _, _)
+
+  check-PropertyPattern :
+    QualityPattern(t1__) -> <id>
+    with <(check-QualityRef <+ error-QualityRef)> t1__
+
+  is-PropertyPattern-with-constructor =
+    ?QualityPattern(_)
+
+  check-PropFilter :
+    Equal() -> <id>
+
+  is-PropFilter-with-constructor =
+    ?Equal()
+
+  check-PropFilter :
+    Conformant() -> <id>
+
+  is-PropFilter-with-constructor =
+    ?Conformant()
+
+  is-PropertyDef-with-constructor =
+    fail
+
+  is-QualityRef-with-constructor =
+    fail
+
+  is-PropertyTerm-with-constructor =
+    fail
+
+  is-PropertyPattern-with-constructor =
+    fail
+
+  is-PropFilter-with-constructor =
+    fail
+
+  check-PropertyDef :
+    amb([h|hs]) -> <check-PropertyDef> h
+
+  check-QualityRef :
+    amb([h|hs]) -> <check-QualityRef> h
+
+  check-PropertyTerm :
+    amb([h|hs]) -> <check-PropertyTerm> h
+
+  check-PropertyPattern :
+    amb([h|hs]) -> <check-PropertyPattern> h
+
+  check-PropFilter :
+    amb([h|hs]) -> <check-PropFilter> h
+
+  error-PropertyDef =
+    debug(!"Unexpected constructor. Expected constructor from sort PropertyDef instead. ")
+
+  error-QualityRef =
+    debug(!"Unexpected constructor. Expected constructor from sort QualityRef instead. ")
+
+  error-PropertyTerm =
+    debug(!"Unexpected constructor. Expected constructor from sort PropertyTerm instead. ")
+
+  error-PropertyPattern =
+    debug(!"Unexpected constructor. Expected constructor from sort PropertyPattern instead. ")
+
+  error-PropFilter =
+    debug(!"Unexpected constructor. Expected constructor from sort PropFilter instead. ")
+
+
+strategies
+  check-SectionKeyword =
+    is-string
+
+  check-example =
+    check-SectionKeyword
+
+  check-SectionKeyword :
+    amb([h|hs]) -> <check-SectionKeyword> h
+
+  error-SectionKeyword =
+    debug(!"Unexpected constructor. Expected string from sort SectionKeyword instead. ")
+
+
+strategies
+  check-example =
+    check-ModuleSection
+
+  check-example =
+    check-BindingRule
+
+  check-ModuleSection :
+    Bindings(t1__) -> <id>
+    with <map(check-BindingRule <+ error-BindingRule)> t1__
+
+  is-ModuleSection-with-constructor =
+    ?Bindings(_)
+
+  check-BindingRule :
+    BindingRule(t1__, t2__, t3__) -> <id>
+    with <(check-Pattern <+ error-Pattern)> t1__
+    with <(check-Constraints <+ error-Constraints)> t2__
+    with <map(check-BindingClause <+ error-BindingClause)> t3__
+
+  is-BindingRule-with-constructor =
+    ?BindingRule(_, _, _)
+
+  is-ModuleSection-with-constructor =
+    fail
+
+  is-BindingRule-with-constructor =
+    fail
+
+  check-ModuleSection :
+    amb([h|hs]) -> <check-ModuleSection> h
+
+  check-BindingRule :
+    amb([h|hs]) -> <check-BindingRule> h
+
+  error-ModuleSection =
+    debug(!"Unexpected constructor. Expected constructor from sort ModuleSection instead. ")
+
+  error-BindingRule =
+    debug(!"Unexpected constructor. Expected constructor from sort BindingRule instead. ")
+
+
+strategies
+  check-example =
+    check-DefKind
+
+  check-example =
+    check-Unique
+
+  check-example =
+    check-RefClausePart
+
+  check-example =
+    check-ImportClausePart
+
+  check-example =
+    check-Alias
+
+  check-example =
+    check-BindingClause
+
+  check-example =
+    check-Disambiguator
+
+  check-BindingClause :
+    DefClause(
+      t1__
+    , t2__
+    , t3__
+    , t4__
+    , t5__
+    , t6__
+    , t7__
+    ) -> <id>
+    with <(check-DefKind <+ error-DefKind)> t1__
+    with <(check-Unique <+ error-Unique)> t2__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t3__
+    with <(check-Term <+ error-Term)> t4__
+    with <map(check-PropertyTerm <+ error-PropertyTerm)> t5__
+    with <(check-InDefScopes <+ error-InDefScopes)> t6__
+    with <(check-Constraints <+ error-Constraints)> t7__
+
+  is-BindingClause-with-constructor =
+    ?DefClause(_, _, _, _, _, _, _)
+
+  check-DefKind :
+    Explicit() -> <id>
+
+  is-DefKind-with-constructor =
+    ?Explicit()
+
+  check-DefKind :
+    Implicit() -> <id>
+
+  is-DefKind-with-constructor =
+    ?Implicit()
+
+  check-Unique :
+    Unique() -> <id>
+
+  is-Unique-with-constructor =
+    ?Unique()
+
+  check-Unique :
+    Unique() -> <id>
+
+  is-Unique-with-constructor =
+    ?Unique()
+
+  check-Unique :
+    NonUnique() -> <id>
+
+  is-Unique-with-constructor =
+    ?NonUnique()
+
+  check-BindingClause :
+    ScopeClause(t1__) -> <id>
+    with <map(check-NamespaceRef <+ error-NamespaceRef)> t1__
+
+  is-BindingClause-with-constructor =
+    ?ScopeClause(_)
+
+  check-BindingClause :
+    NonTransitiveScopeClause(t1__) -> <id>
+    with <map(check-NamespaceRef <+ error-NamespaceRef)> t1__
+
+  is-BindingClause-with-constructor =
+    ?NonTransitiveScopeClause(_)
+
+  check-BindingClause :
+    RefClause(t1__) -> <id>
+    with <map(check-RefClausePart <+ error-RefClausePart)> t1__
+
+  is-BindingClause-with-constructor =
+    ?RefClause(_)
+
+  check-RefClausePart :
+    RefClausePart(t1__, t2__, t3__, t4__, t5__, t6__) -> <id>
+    with <(check-Disambiguator <+ error-Disambiguator)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+    with <(check-Term <+ error-Term)> t3__
+    with <map(check-PropertyPattern <+ error-PropertyPattern)> t4__
+    with <(check-InRefScope <+ error-InRefScope)> t5__
+    with <(check-Constraints <+ error-Constraints)> t6__
+
+  is-RefClausePart-with-constructor =
+    ?RefClausePart(_, _, _, _, _, _)
+
+  check-BindingClause :
+    ImportClause(t1__) -> <id>
+    with <map(check-ImportClausePart <+ error-ImportClausePart)> t1__
+
+  is-BindingClause-with-constructor =
+    ?ImportClause(_)
+
+  check-ImportClausePart :
+    SingleImport(
+      t1__
+    , t2__
+    , t3__
+    , t4__
+    , t5__
+    , t6__
+    , t7__
+    , t8__
+    ) -> <id>
+    with <(check-Disambiguator <+ error-Disambiguator)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+    with <(check-Term <+ error-Term)> t3__
+    with <map(check-PropertyPattern <+ error-PropertyPattern)> t4__
+    with <(check-FromRefScope <+ error-FromRefScope)> t5__
+    with <(check-Alias <+ error-Alias)> t6__
+    with <(check-IntoDefScopes <+ error-IntoDefScopes)> t7__
+    with <(check-Constraints <+ error-Constraints)> t8__
+
+  is-ImportClausePart-with-constructor =
+    ?SingleImport(_, _, _, _, _, _, _, _)
+
+  check-ImportClausePart :
+    WildcardImport(t1__, t2__, t3__, t4__, t5__) -> <id>
+    with <map(check-RestrictedNamespaceRef <+ error-RestrictedNamespaceRef)> t1__
+    with <map(check-PropertyPattern <+ error-PropertyPattern)> t2__
+    with <(check-FromRefScope <+ error-FromRefScope)> t3__
+    with <(check-IntoDefScopes <+ error-IntoDefScopes)> t4__
+    with <(check-Constraints <+ error-Constraints)> t5__
+
+  is-ImportClausePart-with-constructor =
+    ?WildcardImport(_, _, _, _, _)
+
+  check-Alias :
+    None() -> <id>
+
+  is-Alias-with-constructor =
+    ?None()
+
+  check-Alias :
+    Alias(t1__) -> <id>
+    with <(check-Term <+ error-Term)> t1__
+
+  is-Alias-with-constructor =
+    ?Alias(_)
+
+  check-BindingClause :
+    FilterClause(t1__, t2__, t3__, t4__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-Term <+ error-Term)> t2__
+    with <(check-Filters <+ error-Filters)> t3__
+    with <(check-Constraints <+ error-Constraints)> t4__
+
+  is-BindingClause-with-constructor =
+    ?FilterClause(_, _, _, _)
+
+  check-BindingClause :
+    DisambiguateClause(t1__, t2__, t3__, t4__, t5__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-Term <+ error-Term)> t2__
+    with <(check-Filters <+ error-Filters)> t3__
+    with <(check-Disambiguator <+ error-Disambiguator)> t4__
+    with <(check-Constraints <+ error-Constraints)> t5__
+
+  is-BindingClause-with-constructor =
+    ?DisambiguateClause(_, _, _, _, _)
+
+  check-Disambiguator :
+    MinimalDistance(t1__, t2__, t3__) -> <id>
+    with <(check-Term <+ error-Term)> t1__
+    with <(check-Relation <+ error-Relation)> t2__
+    with <(check-Term <+ error-Term)> t3__
+
+  is-Disambiguator-with-constructor =
+    ?MinimalDistance(_, _, _)
+
+  is-DefKind-with-constructor =
+    fail
+
+  is-Unique-with-constructor =
+    fail
+
+  is-RefClausePart-with-constructor =
+    fail
+
+  is-ImportClausePart-with-constructor =
+    fail
+
+  is-Alias-with-constructor =
+    fail
+
+  is-BindingClause-with-constructor =
+    fail
+
+  is-Disambiguator-with-constructor =
+    fail
+
+  check-DefKind :
+    amb([h|hs]) -> <check-DefKind> h
+
+  check-Unique :
+    amb([h|hs]) -> <check-Unique> h
+
+  check-RefClausePart :
+    amb([h|hs]) -> <check-RefClausePart> h
+
+  check-ImportClausePart :
+    amb([h|hs]) -> <check-ImportClausePart> h
+
+  check-Alias :
+    amb([h|hs]) -> <check-Alias> h
+
+  check-BindingClause :
+    amb([h|hs]) -> <check-BindingClause> h
+
+  check-Disambiguator :
+    amb([h|hs]) -> <check-Disambiguator> h
+
+  error-DefKind =
+    debug(!"Unexpected constructor. Expected constructor from sort DefKind instead. ")
+
+  error-Unique =
+    debug(!"Unexpected constructor. Expected constructor from sort Unique instead. ")
+
+  error-RefClausePart =
+    debug(!"Unexpected constructor. Expected constructor from sort RefClausePart instead. ")
+
+  error-ImportClausePart =
+    debug(!"Unexpected constructor. Expected constructor from sort ImportClausePart instead. ")
+
+  error-Alias =
+    debug(!"Unexpected constructor. Expected constructor from sort Alias instead. ")
+
+  error-BindingClause =
+    debug(!"Unexpected constructor. Expected constructor from sort BindingClause instead. ")
+
+  error-Disambiguator =
+    debug(!"Unexpected constructor. Expected constructor from sort Disambiguator instead. ")
+
+
+strategies
+  check-example =
+    check-InDefScopes
+
+  check-example =
+    check-IntoDefScopes
+
+  check-example =
+    check-DefScopes
+
+  check-example =
+    check-DefScope
+
+  check-example =
+    check-InRefScope
+
+  check-example =
+    check-FromRefScope
+
+  check-example =
+    check-RefScope
+
+  check-example =
+    check-Disambiguator
+
+  check-InDefScopes :
+    Current() -> <id>
+
+  is-InDefScopes-with-constructor =
+    ?Current()
+
+  check-InDefScopes :
+    Parenthetical(t1__) -> <id>
+    with <(check-DefScopes <+ error-DefScopes)> t1__
+
+  check-IntoDefScopes :
+    Current() -> <id>
+
+  is-IntoDefScopes-with-constructor =
+    ?Current()
+
+  check-IntoDefScopes :
+    Parenthetical(t1__) -> <id>
+    with <(check-DefScopes <+ error-DefScopes)> t1__
+
+  check-DefScopes :
+    Current() -> <id>
+
+  is-DefScopes-with-constructor =
+    ?Current()
+
+  check-DefScopes :
+    DefScopes(t1__) -> <id>
+    with <map(check-DefScope <+ error-DefScope)> t1__
+
+  is-DefScopes-with-constructor =
+    ?DefScopes(_)
+
+  check-DefScope :
+    Subsequent() -> <id>
+
+  is-DefScope-with-constructor =
+    ?Subsequent()
+
+  check-DefScope :
+    DefScope(t1__) -> <id>
+    with <(check-Term <+ error-Term)> t1__
+
+  is-DefScope-with-constructor =
+    ?DefScope(_)
+
+  check-InRefScope :
+    Current() -> <id>
+
+  is-InRefScope-with-constructor =
+    ?Current()
+
+  check-InRefScope :
+    Parenthetical(t1__) -> <id>
+    with <(check-RefScope <+ error-RefScope)> t1__
+
+  check-FromRefScope :
+    Current() -> <id>
+
+  is-FromRefScope-with-constructor =
+    ?Current()
+
+  check-FromRefScope :
+    Parenthetical(t1__) -> <id>
+    with <(check-RefScope <+ error-RefScope)> t1__
+
+  check-RefScope :
+    Current() -> <id>
+
+  is-RefScope-with-constructor =
+    ?Current()
+
+  check-RefScope :
+    Enclosing(t1__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+
+  is-RefScope-with-constructor =
+    ?Enclosing(_)
+
+  check-RefScope :
+    Context(t1__, t2__, t3__, t4__, t5__) -> <id>
+    with <(check-Disambiguator <+ error-Disambiguator)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+    with <(check-Term <+ error-Term)> t3__
+    with <map(check-PropertyPattern <+ error-PropertyPattern)> t4__
+    with <(check-InRefScope <+ error-InRefScope)> t5__
+
+  is-RefScope-with-constructor =
+    ?Context(_, _, _, _, _)
+
+  check-RefScope :
+    RefScope(t1__) -> <id>
+    with <(check-Term <+ error-Term)> t1__
+
+  is-RefScope-with-constructor =
+    ?RefScope(_)
+
+  check-Disambiguator :
+    All() -> <id>
+
+  is-Disambiguator-with-constructor =
+    ?All()
+
+  check-Disambiguator :
+    Best() -> <id>
+
+  is-Disambiguator-with-constructor =
+    ?Best()
+
+  is-InDefScopes-with-constructor =
+    fail
+
+  is-IntoDefScopes-with-constructor =
+    fail
+
+  is-DefScopes-with-constructor =
+    fail
+
+  is-DefScope-with-constructor =
+    fail
+
+  is-InRefScope-with-constructor =
+    fail
+
+  is-FromRefScope-with-constructor =
+    fail
+
+  is-RefScope-with-constructor =
+    fail
+
+  is-Disambiguator-with-constructor =
+    fail
+
+  check-InDefScopes :
+    amb([h|hs]) -> <check-InDefScopes> h
+
+  check-IntoDefScopes :
+    amb([h|hs]) -> <check-IntoDefScopes> h
+
+  check-DefScopes :
+    amb([h|hs]) -> <check-DefScopes> h
+
+  check-DefScope :
+    amb([h|hs]) -> <check-DefScope> h
+
+  check-InRefScope :
+    amb([h|hs]) -> <check-InRefScope> h
+
+  check-FromRefScope :
+    amb([h|hs]) -> <check-FromRefScope> h
+
+  check-RefScope :
+    amb([h|hs]) -> <check-RefScope> h
+
+  check-Disambiguator :
+    amb([h|hs]) -> <check-Disambiguator> h
+
+  error-InDefScopes =
+    debug(!"Unexpected constructor. Expected constructor from sort InDefScopes instead. ")
+
+  error-IntoDefScopes =
+    debug(!"Unexpected constructor. Expected constructor from sort IntoDefScopes instead. ")
+
+  error-DefScopes =
+    debug(!"Unexpected constructor. Expected constructor from sort DefScopes instead. ")
+
+  error-DefScope =
+    debug(!"Unexpected constructor. Expected constructor from sort DefScope instead. ")
+
+  error-InRefScope =
+    debug(!"Unexpected constructor. Expected constructor from sort InRefScope instead. ")
+
+  error-FromRefScope =
+    debug(!"Unexpected constructor. Expected constructor from sort FromRefScope instead. ")
+
+  error-RefScope =
+    debug(!"Unexpected constructor. Expected constructor from sort RefScope instead. ")
+
+  error-Disambiguator =
+    debug(!"Unexpected constructor. Expected constructor from sort Disambiguator instead. ")
+
+
+strategies
+  check-example =
+    check-Constraints
+
+  check-example =
+    check-Filters
+
+  check-example =
+    check-Proposition
+
+  check-Constraints :
+    NoWhere() -> <id>
+
+  is-Constraints-with-constructor =
+    ?NoWhere()
+
+  check-Constraints :
+    Where(t1__) -> <id>
+    with <(check-Formula <+ error-Formula)> t1__
+
+  is-Constraints-with-constructor =
+    ?Where(_)
+
+  check-Filters :
+    Filter(t1__) -> <id>
+    with <(check-Formula <+ error-Formula)> t1__
+
+  is-Filters-with-constructor =
+    ?Filter(_)
+
+  check-Proposition :
+    PropertyPattern(t1__, t2__, t3__) -> <id>
+    with <(check-VarRef <+ error-VarRef)> t1__
+    with <(check-PropertyRef <+ error-PropertyRef)> t2__
+    with <(check-Pattern <+ error-Pattern)> t3__
+
+  is-Proposition-with-constructor =
+    ?PropertyPattern(_, _, _)
+
+  is-Constraints-with-constructor =
+    fail
+
+  is-Filters-with-constructor =
+    fail
+
+  is-Proposition-with-constructor =
+    fail
+
+  check-Constraints :
+    amb([h|hs]) -> <check-Constraints> h
+
+  check-Filters :
+    amb([h|hs]) -> <check-Filters> h
+
+  check-Proposition :
+    amb([h|hs]) -> <check-Proposition> h
+
+  error-Constraints =
+    debug(!"Unexpected constructor. Expected constructor from sort Constraints instead. ")
+
+  error-Filters =
+    debug(!"Unexpected constructor. Expected constructor from sort Filters instead. ")
+
+  error-Proposition =
+    debug(!"Unexpected constructor. Expected constructor from sort Proposition instead. ")

--- a/Xtext/nabl/src-gen/check/common/Identifiers-chk.str
+++ b/Xtext/nabl/src-gen/check/common/Identifiers-chk.str
@@ -1,0 +1,71 @@
+module nabl/src-gen/check/common/Identifiers-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/common/Identifiers-sig
+
+
+strategies
+  check-LId =
+    is-string
+
+  check-Id =
+    is-string
+
+  check-LCID =
+    is-string
+
+  check-UCID =
+    is-string
+
+  check-example =
+    check-LId
+
+  check-example =
+    check-Id
+
+  check-example =
+    check-LCID
+
+  check-example =
+    check-UCID
+
+  check-LId :
+    amb([h|hs]) -> <check-LId> h
+
+  check-Id :
+    amb([h|hs]) -> <check-Id> h
+
+  check-LCID :
+    amb([h|hs]) -> <check-LCID> h
+
+  check-UCID :
+    amb([h|hs]) -> <check-UCID> h
+
+  error-LId =
+    debug(!"Unexpected constructor. Expected string from sort LId instead. ")
+
+  error-Id =
+    debug(!"Unexpected constructor. Expected string from sort Id instead. ")
+
+  error-LCID =
+    debug(!"Unexpected constructor. Expected string from sort LCID instead. ")
+
+  error-UCID =
+    debug(!"Unexpected constructor. Expected string from sort UCID instead. ")
+
+
+strategies
+  check-Keyword =
+    is-string
+
+  check-example =
+    check-Keyword
+
+  check-Keyword :
+    amb([h|hs]) -> <check-Keyword> h
+
+  error-Keyword =
+    debug(!"Unexpected constructor. Expected string from sort Keyword instead. ")

--- a/Xtext/nabl/src-gen/check/common/Layout-chk.str
+++ b/Xtext/nabl/src-gen/check/common/Layout-chk.str
@@ -1,0 +1,57 @@
+module nabl/src-gen/check/common/Layout-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/common/Layout-sig
+
+
+strategies
+  check-Eof =
+    is-string
+
+  check-LongCom =
+    is-string
+
+  check-CommChar =
+    is-string
+
+  check-Asterisk =
+    is-string
+
+  check-example =
+    check-Eof
+
+  check-example =
+    check-LongCom
+
+  check-example =
+    check-CommChar
+
+  check-example =
+    check-Asterisk
+
+  check-Eof :
+    amb([h|hs]) -> <check-Eof> h
+
+  check-LongCom :
+    amb([h|hs]) -> <check-LongCom> h
+
+  check-CommChar :
+    amb([h|hs]) -> <check-CommChar> h
+
+  check-Asterisk :
+    amb([h|hs]) -> <check-Asterisk> h
+
+  error-Eof =
+    debug(!"Unexpected constructor. Expected string from sort Eof instead. ")
+
+  error-LongCom =
+    debug(!"Unexpected constructor. Expected string from sort LongCom instead. ")
+
+  error-CommChar =
+    debug(!"Unexpected constructor. Expected string from sort CommChar instead. ")
+
+  error-Asterisk =
+    debug(!"Unexpected constructor. Expected string from sort Asterisk instead. ")

--- a/Xtext/nabl/src-gen/check/core/Modules-chk.str
+++ b/Xtext/nabl/src-gen/check/core/Modules-chk.str
@@ -1,0 +1,112 @@
+module nabl/src-gen/check/core/Modules-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Modules-sig
+
+
+strategies
+  check-example =
+    check-Module
+
+  check-example =
+    check-ModuleSection
+
+  check-example =
+    check-ImportModule
+
+  check-Module :
+    Module(t1__, t2__) -> <id>
+    with <(check-ModuleID <+ error-ModuleID)> t1__
+    with <map(check-ModuleSection <+ error-ModuleSection)> t2__
+
+  is-Module-with-constructor =
+    ?Module(_, _)
+
+  check-ModuleSection :
+    Imports(t1__) -> <id>
+    with <map(check-ImportModule <+ error-ImportModule)> t1__
+
+  is-ModuleSection-with-constructor =
+    ?Imports(_)
+
+  check-ImportModule :
+    ImportWildcard(t1__) -> <id>
+    with <(check-ModuleID <+ error-ModuleID)> t1__
+
+  is-ImportModule-with-constructor =
+    ?ImportWildcard(_)
+
+  check-ImportModule :
+    Import(t1__) -> <id>
+    with <(check-ModuleID <+ error-ModuleID)> t1__
+
+  is-ImportModule-with-constructor =
+    ?Import(_)
+
+  is-Module-with-constructor =
+    fail
+
+  is-ModuleSection-with-constructor =
+    fail
+
+  is-ImportModule-with-constructor =
+    fail
+
+  check-Module :
+    amb([h|hs]) -> <check-Module> h
+
+  check-ModuleSection :
+    amb([h|hs]) -> <check-ModuleSection> h
+
+  check-ImportModule :
+    amb([h|hs]) -> <check-ImportModule> h
+
+  error-Module =
+    debug(!"Unexpected constructor. Expected constructor from sort Module instead. ")
+
+  error-ModuleSection =
+    debug(!"Unexpected constructor. Expected constructor from sort ModuleSection instead. ")
+
+  error-ImportModule =
+    debug(!"Unexpected constructor. Expected constructor from sort ImportModule instead. ")
+
+
+strategies
+  check-ModuleID =
+    is-string
+
+  check-ModuleIDPart =
+    is-string
+
+  check-SectionKeyword =
+    is-string
+
+  check-example =
+    check-ModuleID
+
+  check-example =
+    check-ModuleIDPart
+
+  check-example =
+    check-SectionKeyword
+
+  check-ModuleID :
+    amb([h|hs]) -> <check-ModuleID> h
+
+  check-ModuleIDPart :
+    amb([h|hs]) -> <check-ModuleIDPart> h
+
+  check-SectionKeyword :
+    amb([h|hs]) -> <check-SectionKeyword> h
+
+  error-ModuleID =
+    debug(!"Unexpected constructor. Expected string from sort ModuleID instead. ")
+
+  error-ModuleIDPart =
+    debug(!"Unexpected constructor. Expected string from sort ModuleIDPart instead. ")
+
+  error-SectionKeyword =
+    debug(!"Unexpected constructor. Expected string from sort SectionKeyword instead. ")

--- a/Xtext/nabl/src-gen/check/core/Namespaces-chk.str
+++ b/Xtext/nabl/src-gen/check/core/Namespaces-chk.str
@@ -1,0 +1,128 @@
+module nabl/src-gen/check/core/Namespaces-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Namespaces-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/core/Modules-sig
+
+
+imports
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/core/Modules-chk
+
+
+strategies
+  check-NamespaceID =
+    is-string
+
+  check-SectionKeyword =
+    is-string
+
+  check-example =
+    check-NamespaceID
+
+  check-example =
+    check-SectionKeyword
+
+  check-NamespaceID :
+    amb([h|hs]) -> <check-NamespaceID> h
+
+  check-SectionKeyword :
+    amb([h|hs]) -> <check-SectionKeyword> h
+
+  error-NamespaceID =
+    debug(!"Unexpected constructor. Expected string from sort NamespaceID instead. ")
+
+  error-SectionKeyword =
+    debug(!"Unexpected constructor. Expected string from sort SectionKeyword instead. ")
+
+
+strategies
+  check-example =
+    check-ModuleSection
+
+  check-example =
+    check-NamespaceDef
+
+  check-example =
+    check-NamespaceRef
+
+  check-example =
+    check-LanguageRef
+
+  check-ModuleSection :
+    Namespaces(t1__) -> <id>
+    with <map(check-NamespaceDef <+ error-NamespaceDef)> t1__
+
+  is-ModuleSection-with-constructor =
+    ?Namespaces(_)
+
+  check-NamespaceDef :
+    NamespaceDef(t1__) -> <id>
+    with <(check-NamespaceID <+ error-NamespaceID)> t1__
+
+  is-NamespaceDef-with-constructor =
+    ?NamespaceDef(_)
+
+  check-NamespaceRef :
+    NamespaceRef(t1__, t2__) -> <id>
+    with <(check-LanguageRef <+ error-LanguageRef)> t1__
+    with <(check-NamespaceID <+ error-NamespaceID)> t2__
+
+  is-NamespaceRef-with-constructor =
+    ?NamespaceRef(_, _)
+
+  check-LanguageRef :
+    CurrentLanguage() -> <id>
+
+  is-LanguageRef-with-constructor =
+    ?CurrentLanguage()
+
+  check-LanguageRef :
+    LanguageRef(t1__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+
+  is-LanguageRef-with-constructor =
+    ?LanguageRef(_)
+
+  is-ModuleSection-with-constructor =
+    fail
+
+  is-NamespaceDef-with-constructor =
+    fail
+
+  is-NamespaceRef-with-constructor =
+    fail
+
+  is-LanguageRef-with-constructor =
+    fail
+
+  check-ModuleSection :
+    amb([h|hs]) -> <check-ModuleSection> h
+
+  check-NamespaceDef :
+    amb([h|hs]) -> <check-NamespaceDef> h
+
+  check-NamespaceRef :
+    amb([h|hs]) -> <check-NamespaceRef> h
+
+  check-LanguageRef :
+    amb([h|hs]) -> <check-LanguageRef> h
+
+  error-ModuleSection =
+    debug(!"Unexpected constructor. Expected constructor from sort ModuleSection instead. ")
+
+  error-NamespaceDef =
+    debug(!"Unexpected constructor. Expected constructor from sort NamespaceDef instead. ")
+
+  error-NamespaceRef =
+    debug(!"Unexpected constructor. Expected constructor from sort NamespaceRef instead. ")
+
+  error-LanguageRef =
+    debug(!"Unexpected constructor. Expected constructor from sort LanguageRef instead. ")

--- a/Xtext/nabl/src-gen/check/core/Properties-chk.str
+++ b/Xtext/nabl/src-gen/check/core/Properties-chk.str
@@ -1,0 +1,130 @@
+module nabl/src-gen/check/core/Properties-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Properties-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Signatures-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Formulas-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+
+
+imports
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/terms/Signatures-chk
+  nabl/src-gen/check/terms/Vars-chk
+  nabl/src-gen/check/terms/Terms-chk
+  nabl/src-gen/check/formulas/Formulas-chk
+  nabl/src-gen/check/core/Namespaces-chk
+
+
+strategies
+  check-PropertyID =
+    is-string
+
+  check-SectionKeyword =
+    is-string
+
+  check-Relation =
+    is-string
+
+  check-example =
+    check-PropertyID
+
+  check-example =
+    check-SectionKeyword
+
+  check-example =
+    check-Relation
+
+  check-PropertyID :
+    amb([h|hs]) -> <check-PropertyID> h
+
+  check-SectionKeyword :
+    amb([h|hs]) -> <check-SectionKeyword> h
+
+  check-Relation :
+    amb([h|hs]) -> <check-Relation> h
+
+  error-PropertyID =
+    debug(!"Unexpected constructor. Expected string from sort PropertyID instead. ")
+
+  error-SectionKeyword =
+    debug(!"Unexpected constructor. Expected string from sort SectionKeyword instead. ")
+
+  error-Relation =
+    debug(!"Unexpected constructor. Expected string from sort Relation instead. ")
+
+
+strategies
+  check-example =
+    check-ModuleSection
+
+  check-example =
+    check-PropertyDef
+
+  check-example =
+    check-PropertyRef
+
+  check-ModuleSection :
+    Properties(t1__) -> <id>
+    with <map(check-PropertyDef <+ error-PropertyDef)> t1__
+
+  is-ModuleSection-with-constructor =
+    ?Properties(_)
+
+  check-PropertyDef :
+    PropertyDef(t1__, t2__, t3__) -> <id>
+    with <(check-PropertyID <+ error-PropertyID)> t1__
+    with <map(check-NamespaceRef <+ error-NamespaceRef)> t2__
+    with <(check-Sort <+ error-Sort)> t3__
+
+  is-PropertyDef-with-constructor =
+    ?PropertyDef(_, _, _)
+
+  check-PropertyRef :
+    TypeProp() -> <id>
+
+  is-PropertyRef-with-constructor =
+    ?TypeProp()
+
+  check-PropertyRef :
+    PropertyRef(t1__) -> <id>
+    with <(check-PropertyID <+ error-PropertyID)> t1__
+
+  is-PropertyRef-with-constructor =
+    ?PropertyRef(_)
+
+  is-ModuleSection-with-constructor =
+    fail
+
+  is-PropertyDef-with-constructor =
+    fail
+
+  is-PropertyRef-with-constructor =
+    fail
+
+  check-ModuleSection :
+    amb([h|hs]) -> <check-ModuleSection> h
+
+  check-PropertyDef :
+    amb([h|hs]) -> <check-PropertyDef> h
+
+  check-PropertyRef :
+    amb([h|hs]) -> <check-PropertyRef> h
+
+  error-ModuleSection =
+    debug(!"Unexpected constructor. Expected constructor from sort ModuleSection instead. ")
+
+  error-PropertyDef =
+    debug(!"Unexpected constructor. Expected constructor from sort PropertyDef instead. ")
+
+  error-PropertyRef =
+    debug(!"Unexpected constructor. Expected constructor from sort PropertyRef instead. ")

--- a/Xtext/nabl/src-gen/check/core/Scopes-chk.str
+++ b/Xtext/nabl/src-gen/check/core/Scopes-chk.str
@@ -1,0 +1,146 @@
+module nabl/src-gen/check/core/Scopes-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Scopes-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/core/Namespaces-chk
+  nabl/src-gen/check/terms/Vars-chk
+
+
+strategies
+  check-ScopeID =
+    is-string
+
+  check-example =
+    check-ScopeID
+
+  check-ScopeID :
+    amb([h|hs]) -> <check-ScopeID> h
+
+  error-ScopeID =
+    debug(!"Unexpected constructor. Expected string from sort ScopeID instead. ")
+
+
+strategies
+  check-example =
+    check-LocalScope
+
+  check-example =
+    check-Scope
+
+  check-LocalScope :
+    NamedScope(t1__, t2__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-VarRef <+ error-VarRef)> t2__
+
+  is-LocalScope-with-constructor =
+    ?NamedScope(_, _)
+
+  check-LocalScope :
+    CurrentScope(t1__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+
+  is-LocalScope-with-constructor =
+    ?CurrentScope(_)
+
+  check-LocalScope :
+    TermScope(t1__, t2__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-VarRef <+ error-VarRef)> t2__
+
+  is-LocalScope-with-constructor =
+    ?TermScope(_, _)
+
+  check-LocalScope :
+    Enclosing(t1__, t2__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-LocalScope <+ error-LocalScope)> t2__
+
+  is-LocalScope-with-constructor =
+    ?Enclosing(_, _)
+
+  check-Scope :
+    GlobalScope() -> <id>
+
+  is-Scope-with-constructor =
+    ?GlobalScope()
+
+  check-Scope :
+    t1__ -> <id>
+    where not(is-Scope-with-constructor)
+    where <(check-LocalScope <+ error-LocalScope)> t1__
+
+  check-Scope :
+    Anonymous(t1__) -> <id>
+    with <(check-Scope <+ error-Scope)> t1__
+
+  is-Scope-with-constructor =
+    ?Anonymous(_)
+
+  is-LocalScope-with-constructor =
+    fail
+
+  is-Scope-with-constructor =
+    fail
+
+  check-LocalScope :
+    amb([h|hs]) -> <check-LocalScope> h
+
+  check-Scope :
+    amb([h|hs]) -> <check-Scope> h
+
+  error-LocalScope =
+    debug(!"Unexpected constructor. Expected constructor from sort LocalScope instead. ")
+
+  error-Scope =
+    debug(!"Unexpected constructor. Expected constructor from sort Scope instead. ")
+
+
+strategies
+  check-example =
+    check-Clause
+
+  check-Clause :
+    ChildScope(t1__, t2__) -> <id>
+    with <(check-Scope <+ error-Scope)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+
+  is-Clause-with-constructor =
+    ?ChildScope(_, _)
+
+  check-Clause :
+    SubsequentScope(t1__, t2__) -> <id>
+    with <(check-Scope <+ error-Scope)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+
+  is-Clause-with-constructor =
+    ?SubsequentScope(_, _)
+
+  check-Clause :
+    NodeScope(t1__, t2__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-VarRef <+ error-VarRef)> t2__
+
+  is-Clause-with-constructor =
+    ?NodeScope(_, _)
+
+  is-Clause-with-constructor =
+    fail
+
+  check-Clause :
+    amb([h|hs]) -> <check-Clause> h
+
+  error-Clause =
+    debug(!"Unexpected constructor. Expected constructor from sort Clause instead. ")

--- a/Xtext/nabl/src-gen/check/formulas/Formulas-chk.str
+++ b/Xtext/nabl/src-gen/check/formulas/Formulas-chk.str
@@ -1,0 +1,63 @@
+module nabl/src-gen/check/formulas/Formulas-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/formulas/Formulas-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Propositions-sig
+
+
+imports
+  nabl/src-gen/check/terms/Terms-chk
+  nabl/src-gen/check/formulas/Propositions-chk
+
+
+strategies
+  check-example =
+    check-Formula
+
+  check-Formula :
+    t1__ -> <id>
+    where not(is-Formula-with-constructor)
+    where <(check-Proposition <+ error-Proposition)> t1__
+
+  check-Formula :
+    Not(t1__) -> <id>
+    with <(check-Formula <+ error-Formula)> t1__
+
+  is-Formula-with-constructor =
+    ?Not(_)
+
+  check-Formula :
+    And(t1__, t2__) -> <id>
+    with <(check-Formula <+ error-Formula)> t1__
+    with <(check-Formula <+ error-Formula)> t2__
+
+  is-Formula-with-constructor =
+    ?And(_, _)
+
+  check-Formula :
+    Or(t1__, t2__) -> <id>
+    with <(check-Formula <+ error-Formula)> t1__
+    with <(check-Formula <+ error-Formula)> t2__
+
+  is-Formula-with-constructor =
+    ?Or(_, _)
+
+  check-Formula :
+    Parenthetical(t1__) -> <id>
+    with <(check-Formula <+ error-Formula)> t1__
+
+  is-Formula-with-constructor =
+    fail
+
+  check-Formula :
+    amb([h|hs]) -> <check-Formula> h
+
+  error-Formula =
+    debug(!"Unexpected constructor. Expected constructor from sort Formula instead. ")

--- a/Xtext/nabl/src-gen/check/formulas/Messages-chk.str
+++ b/Xtext/nabl/src-gen/check/formulas/Messages-chk.str
@@ -1,0 +1,68 @@
+module nabl/src-gen/check/formulas/Messages-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/formulas/Messages-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/check/terms/Terms-chk
+
+
+strategies
+  check-example =
+    check-Message
+
+  check-example =
+    check-MessageKind
+
+  check-Message :
+    Message(t1__, t2__, t3__) -> <id>
+    with <(check-MessageKind <+ error-MessageKind)> t1__
+    with <(check-Term <+ error-Term)> t2__
+    with <(check-Term <+ error-Term)> t3__
+
+  is-Message-with-constructor =
+    ?Message(_, _, _)
+
+  check-MessageKind :
+    Error() -> <id>
+
+  is-MessageKind-with-constructor =
+    ?Error()
+
+  check-MessageKind :
+    Warning() -> <id>
+
+  is-MessageKind-with-constructor =
+    ?Warning()
+
+  check-MessageKind :
+    Note() -> <id>
+
+  is-MessageKind-with-constructor =
+    ?Note()
+
+  is-Message-with-constructor =
+    fail
+
+  is-MessageKind-with-constructor =
+    fail
+
+  check-Message :
+    amb([h|hs]) -> <check-Message> h
+
+  check-MessageKind :
+    amb([h|hs]) -> <check-MessageKind> h
+
+  error-Message =
+    debug(!"Unexpected constructor. Expected constructor from sort Message instead. ")
+
+  error-MessageKind =
+    debug(!"Unexpected constructor. Expected constructor from sort MessageKind instead. ")

--- a/Xtext/nabl/src-gen/check/formulas/Propositions-chk.str
+++ b/Xtext/nabl/src-gen/check/formulas/Propositions-chk.str
@@ -1,0 +1,117 @@
+module nabl/src-gen/check/formulas/Propositions-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/formulas/Propositions-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/core/Scopes-sig
+  nabl/src-gen/signatures/core/Properties-sig
+
+
+imports
+  nabl/src-gen/check/terms/Terms-chk
+  nabl/src-gen/check/terms/Vars-chk
+  nabl/src-gen/check/core/Namespaces-chk
+  nabl/src-gen/check/core/Scopes-chk
+  nabl/src-gen/check/core/Properties-chk
+
+
+strategies
+  check-example =
+    check-Proposition
+
+  check-Proposition :
+    True() -> <id>
+
+  is-Proposition-with-constructor =
+    ?True()
+
+  check-Proposition :
+    False() -> <id>
+
+  is-Proposition-with-constructor =
+    ?False()
+
+  check-Proposition :
+    Eq(t1__, t2__) -> <id>
+    with <(check-VarRef <+ error-VarRef)> t1__
+    with <(check-Term <+ error-Term)> t2__
+
+  is-Proposition-with-constructor =
+    ?Eq(_, _)
+
+  check-Proposition :
+    Match(t1__, t2__) -> <id>
+    with <(check-VarRef <+ error-VarRef)> t1__
+    with <(check-Pattern <+ error-Pattern)> t2__
+
+  is-Proposition-with-constructor =
+    ?Match(_, _)
+
+  check-Proposition :
+    DefOf(t1__, t2__) -> <id>
+    with <(check-VarRef <+ error-VarRef)> t1__
+    with <(check-Var <+ error-Var)> t2__
+
+  is-Proposition-with-constructor =
+    ?DefOf(_, _)
+
+  check-Proposition :
+    DefOf(t1__, t2__, t3__) -> <id>
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t1__
+    with <(check-VarRef <+ error-VarRef)> t2__
+    with <(check-Var <+ error-Var)> t3__
+
+  is-Proposition-with-constructor =
+    ?DefOf(_, _, _)
+
+  check-Proposition :
+    ScopeOf(t1__, t2__) -> <id>
+    with <(check-Scope <+ error-Scope)> t1__
+    with <(check-Var <+ error-Var)> t2__
+
+  is-Proposition-with-constructor =
+    ?ScopeOf(_, _)
+
+  check-Proposition :
+    ResolvesTo(t1__, t2__, t3__) -> <id>
+    with <(check-Term <+ error-Term)> t1__
+    with <(check-NamespaceRef <+ error-NamespaceRef)> t2__
+    with <(check-Var <+ error-Var)> t3__
+
+  is-Proposition-with-constructor =
+    ?ResolvesTo(_, _, _)
+
+  check-Proposition :
+    HasProperty(t1__, t2__, t3__) -> <id>
+    with <(check-VarRef <+ error-VarRef)> t1__
+    with <(check-PropertyRef <+ error-PropertyRef)> t2__
+    with <(check-Var <+ error-Var)> t3__
+
+  is-Proposition-with-constructor =
+    ?HasProperty(_, _, _)
+
+  check-Proposition :
+    InRelation(t1__, t2__, t3__) -> <id>
+    with <(check-Term <+ error-Term)> t1__
+    with <(check-Relation <+ error-Relation)> t2__
+    with <(check-Term <+ error-Term)> t3__
+
+  is-Proposition-with-constructor =
+    ?InRelation(_, _, _)
+
+  is-Proposition-with-constructor =
+    fail
+
+  check-Proposition :
+    amb([h|hs]) -> <check-Proposition> h
+
+  error-Proposition =
+    debug(!"Unexpected constructor. Expected constructor from sort Proposition instead. ")

--- a/Xtext/nabl/src-gen/check/lexical/Identifiers-chk.str
+++ b/Xtext/nabl/src-gen/check/lexical/Identifiers-chk.str
@@ -1,0 +1,81 @@
+module nabl/src-gen/check/lexical/Identifiers-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/lexical/Identifiers-sig
+
+
+strategies
+  check-Id =
+    is-string
+
+  check-LId =
+    is-string
+
+  check-LCID =
+    is-string
+
+  check-UCID =
+    is-string
+
+  check-ModuleID =
+    is-string
+
+  check-ModuleIDPart =
+    is-string
+
+  check-example =
+    check-Id
+
+  check-example =
+    check-LId
+
+  check-example =
+    check-LCID
+
+  check-example =
+    check-UCID
+
+  check-example =
+    check-ModuleID
+
+  check-example =
+    check-ModuleIDPart
+
+  check-Id :
+    amb([h|hs]) -> <check-Id> h
+
+  check-LId :
+    amb([h|hs]) -> <check-LId> h
+
+  check-LCID :
+    amb([h|hs]) -> <check-LCID> h
+
+  check-UCID :
+    amb([h|hs]) -> <check-UCID> h
+
+  check-ModuleID :
+    amb([h|hs]) -> <check-ModuleID> h
+
+  check-ModuleIDPart :
+    amb([h|hs]) -> <check-ModuleIDPart> h
+
+  error-Id =
+    debug(!"Unexpected constructor. Expected string from sort Id instead. ")
+
+  error-LId =
+    debug(!"Unexpected constructor. Expected string from sort LId instead. ")
+
+  error-LCID =
+    debug(!"Unexpected constructor. Expected string from sort LCID instead. ")
+
+  error-UCID =
+    debug(!"Unexpected constructor. Expected string from sort UCID instead. ")
+
+  error-ModuleID =
+    debug(!"Unexpected constructor. Expected string from sort ModuleID instead. ")
+
+  error-ModuleIDPart =
+    debug(!"Unexpected constructor. Expected string from sort ModuleIDPart instead. ")

--- a/Xtext/nabl/src-gen/check/lexical/Layout-chk.str
+++ b/Xtext/nabl/src-gen/check/lexical/Layout-chk.str
@@ -1,0 +1,57 @@
+module nabl/src-gen/check/lexical/Layout-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/lexical/Layout-sig
+
+
+strategies
+  check-Eof =
+    is-string
+
+  check-LongCom =
+    is-string
+
+  check-CommChar =
+    is-string
+
+  check-Asterisk =
+    is-string
+
+  check-example =
+    check-Eof
+
+  check-example =
+    check-LongCom
+
+  check-example =
+    check-CommChar
+
+  check-example =
+    check-Asterisk
+
+  check-Eof :
+    amb([h|hs]) -> <check-Eof> h
+
+  check-LongCom :
+    amb([h|hs]) -> <check-LongCom> h
+
+  check-CommChar :
+    amb([h|hs]) -> <check-CommChar> h
+
+  check-Asterisk :
+    amb([h|hs]) -> <check-Asterisk> h
+
+  error-Eof =
+    debug(!"Unexpected constructor. Expected string from sort Eof instead. ")
+
+  error-LongCom =
+    debug(!"Unexpected constructor. Expected string from sort LongCom instead. ")
+
+  error-CommChar =
+    debug(!"Unexpected constructor. Expected string from sort CommChar instead. ")
+
+  error-Asterisk =
+    debug(!"Unexpected constructor. Expected string from sort Asterisk instead. ")

--- a/Xtext/nabl/src-gen/check/terms/Constants-chk.str
+++ b/Xtext/nabl/src-gen/check/terms/Constants-chk.str
@@ -1,0 +1,83 @@
+module nabl/src-gen/check/terms/Constants-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Constants-sig
+
+
+strategies
+  check-Int =
+    is-string
+
+  check-Real =
+    is-string
+
+  check-String =
+    is-string
+
+  check-StrChar =
+    is-string
+
+  check-example =
+    check-Int
+
+  check-example =
+    check-Real
+
+  check-example =
+    check-String
+
+  check-example =
+    check-StrChar
+
+  check-Int :
+    amb([h|hs]) -> <check-Int> h
+
+  check-Real :
+    amb([h|hs]) -> <check-Real> h
+
+  check-String :
+    amb([h|hs]) -> <check-String> h
+
+  check-StrChar :
+    amb([h|hs]) -> <check-StrChar> h
+
+  error-Int =
+    debug(!"Unexpected constructor. Expected string from sort Int instead. ")
+
+  error-Real =
+    debug(!"Unexpected constructor. Expected string from sort Real instead. ")
+
+  error-String =
+    debug(!"Unexpected constructor. Expected string from sort String instead. ")
+
+  error-StrChar =
+    debug(!"Unexpected constructor. Expected string from sort StrChar instead. ")
+
+
+strategies
+  check-Char =
+    is-string
+
+  check-CharChar =
+    is-string
+
+  check-example =
+    check-Char
+
+  check-example =
+    check-CharChar
+
+  check-Char :
+    amb([h|hs]) -> <check-Char> h
+
+  check-CharChar :
+    amb([h|hs]) -> <check-CharChar> h
+
+  error-Char =
+    debug(!"Unexpected constructor. Expected string from sort Char instead. ")
+
+  error-CharChar =
+    debug(!"Unexpected constructor. Expected string from sort CharChar instead. ")

--- a/Xtext/nabl/src-gen/check/terms/Signatures-chk.str
+++ b/Xtext/nabl/src-gen/check/terms/Signatures-chk.str
@@ -1,0 +1,151 @@
+module nabl/src-gen/check/terms/Signatures-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Signatures-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Constants-sig
+
+
+imports
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/terms/Constants-chk
+
+
+strategies
+  check-example =
+    check-Sort
+
+  check-Sort :
+    SortVar(t1__) -> <id>
+    with <(check-LCID <+ error-LCID)> t1__
+
+  is-Sort-with-constructor =
+    ?SortVar(_)
+
+  check-Sort :
+    SortNoArgs(t1__) -> <id>
+    with <(check-UCID <+ error-UCID)> t1__
+
+  is-Sort-with-constructor =
+    ?SortNoArgs(_)
+
+  check-Sort :
+    Sort(t1__, t2__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+    with <map(check-Sort <+ error-Sort)> t2__
+
+  is-Sort-with-constructor =
+    ?Sort(_, _)
+
+  is-Sort-with-constructor =
+    fail
+
+  check-Sort :
+    amb([h|hs]) -> <check-Sort> h
+
+  error-Sort =
+    debug(!"Unexpected constructor. Expected constructor from sort Sort instead. ")
+
+
+strategies
+  check-example =
+    check-TypeDecl
+
+  check-example =
+    check-PPTerm
+
+  check-TypeDecl :
+    TypeDecl(t1__, t2__, t3__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+    with <(check-TypeParams <+ error-TypeParams)> t2__
+    with <(check-PPTerm <+ error-PPTerm)> t3__
+
+  is-TypeDecl-with-constructor =
+    ?TypeDecl(_, _, _)
+
+  check-TypeDecl :
+    TypeDeclQ(t1__, t2__, t3__) -> <id>
+    with <(check-String <+ error-String)> t1__
+    with <(check-TypeParams <+ error-TypeParams)> t2__
+    with <(check-PPTerm <+ error-PPTerm)> t3__
+
+  is-TypeDecl-with-constructor =
+    ?TypeDeclQ(_, _, _)
+
+  check-PPTerm :
+    Str(t1__) -> <id>
+    with <(check-String <+ error-String)> t1__
+
+  is-PPTerm-with-constructor =
+    ?Str(_)
+
+  is-TypeDecl-with-constructor =
+    fail
+
+  is-PPTerm-with-constructor =
+    fail
+
+  check-TypeDecl :
+    amb([h|hs]) -> <check-TypeDecl> h
+
+  check-PPTerm :
+    amb([h|hs]) -> <check-PPTerm> h
+
+  error-TypeDecl =
+    debug(!"Unexpected constructor. Expected constructor from sort TypeDecl instead. ")
+
+  error-PPTerm =
+    debug(!"Unexpected constructor. Expected constructor from sort PPTerm instead. ")
+
+
+strategies
+  check-example =
+    check-TypeParams
+
+  check-example =
+    check-TypeParam
+
+  check-TypeParams :
+    NoTypeParams() -> <id>
+
+  is-TypeParams-with-constructor =
+    ?NoTypeParams()
+
+  check-TypeParams :
+    TypeParams(t1__) -> <id>
+    with <map(check-TypeParam <+ error-TypeParam)> t1__
+
+  is-TypeParams-with-constructor =
+    ?TypeParams(_)
+
+  check-TypeParam :
+    TypeParam(t1__, t2__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+    with <(check-Sort <+ error-Sort)> t2__
+
+  is-TypeParam-with-constructor =
+    ?TypeParam(_, _)
+
+  is-TypeParams-with-constructor =
+    fail
+
+  is-TypeParam-with-constructor =
+    fail
+
+  check-TypeParams :
+    amb([h|hs]) -> <check-TypeParams> h
+
+  check-TypeParam :
+    amb([h|hs]) -> <check-TypeParam> h
+
+  error-TypeParams =
+    debug(!"Unexpected constructor. Expected constructor from sort TypeParams instead. ")
+
+  error-TypeParam =
+    debug(!"Unexpected constructor. Expected constructor from sort TypeParam instead. ")

--- a/Xtext/nabl/src-gen/check/terms/StringQuotations-chk.str
+++ b/Xtext/nabl/src-gen/check/terms/StringQuotations-chk.str
@@ -1,0 +1,190 @@
+module nabl/src-gen/check/terms/StringQuotations-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/StringQuotations-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/check/terms/Terms-chk
+
+
+strategies
+  check-example =
+    check-PPTerm
+
+  check-PPTerm :
+    t1__ -> <id>
+    where not(is-PPTerm-with-constructor)
+    where <(check-StringQuotation <+ error-StringQuotation)> t1__
+
+  is-PPTerm-with-constructor =
+    fail
+
+  check-StringQuotedChars1 =
+    is-string
+
+  check-QuotedBracket1 =
+    is-string
+
+  check-Dollar1 =
+    is-string
+
+  check-StringQuotedChars2 =
+    is-string
+
+  check-QuotedBracket2 =
+    is-string
+
+  check-Dollar2 =
+    is-string
+
+  check-StringQuotedChars3 =
+    is-string
+
+  check-QuotedBracket3 =
+    is-string
+
+  check-Dollar3 =
+    is-string
+
+  check-StringQuotedChars4 =
+    is-string
+
+  check-QuotedBracket4 =
+    is-string
+
+  check-Dollar4 =
+    is-string
+
+  check-Padding =
+    is-string
+
+  check-example =
+    check-StringQuotedChars1
+
+  check-example =
+    check-QuotedBracket1
+
+  check-example =
+    check-Dollar1
+
+  check-example =
+    check-StringQuotedChars2
+
+  check-example =
+    check-QuotedBracket2
+
+  check-example =
+    check-Dollar2
+
+  check-example =
+    check-StringQuotedChars3
+
+  check-example =
+    check-QuotedBracket3
+
+  check-example =
+    check-Dollar3
+
+  check-example =
+    check-StringQuotedChars4
+
+  check-example =
+    check-QuotedBracket4
+
+  check-example =
+    check-Dollar4
+
+  check-example =
+    check-Padding
+
+  check-PPTerm :
+    amb([h|hs]) -> <check-PPTerm> h
+
+  check-StringQuotedChars1 :
+    amb([h|hs]) -> <check-StringQuotedChars1> h
+
+  check-QuotedBracket1 :
+    amb([h|hs]) -> <check-QuotedBracket1> h
+
+  check-Dollar1 :
+    amb([h|hs]) -> <check-Dollar1> h
+
+  check-StringQuotedChars2 :
+    amb([h|hs]) -> <check-StringQuotedChars2> h
+
+  check-QuotedBracket2 :
+    amb([h|hs]) -> <check-QuotedBracket2> h
+
+  check-Dollar2 :
+    amb([h|hs]) -> <check-Dollar2> h
+
+  check-StringQuotedChars3 :
+    amb([h|hs]) -> <check-StringQuotedChars3> h
+
+  check-QuotedBracket3 :
+    amb([h|hs]) -> <check-QuotedBracket3> h
+
+  check-Dollar3 :
+    amb([h|hs]) -> <check-Dollar3> h
+
+  check-StringQuotedChars4 :
+    amb([h|hs]) -> <check-StringQuotedChars4> h
+
+  check-QuotedBracket4 :
+    amb([h|hs]) -> <check-QuotedBracket4> h
+
+  check-Dollar4 :
+    amb([h|hs]) -> <check-Dollar4> h
+
+  check-Padding :
+    amb([h|hs]) -> <check-Padding> h
+
+  error-StringQuotedChars1 =
+    debug(!"Unexpected constructor. Expected string from sort StringQuotedChars1 instead. ")
+
+  error-QuotedBracket1 =
+    debug(!"Unexpected constructor. Expected string from sort QuotedBracket1 instead. ")
+
+  error-Dollar1 =
+    debug(!"Unexpected constructor. Expected string from sort Dollar1 instead. ")
+
+  error-StringQuotedChars2 =
+    debug(!"Unexpected constructor. Expected string from sort StringQuotedChars2 instead. ")
+
+  error-QuotedBracket2 =
+    debug(!"Unexpected constructor. Expected string from sort QuotedBracket2 instead. ")
+
+  error-Dollar2 =
+    debug(!"Unexpected constructor. Expected string from sort Dollar2 instead. ")
+
+  error-StringQuotedChars3 =
+    debug(!"Unexpected constructor. Expected string from sort StringQuotedChars3 instead. ")
+
+  error-QuotedBracket3 =
+    debug(!"Unexpected constructor. Expected string from sort QuotedBracket3 instead. ")
+
+  error-Dollar3 =
+    debug(!"Unexpected constructor. Expected string from sort Dollar3 instead. ")
+
+  error-StringQuotedChars4 =
+    debug(!"Unexpected constructor. Expected string from sort StringQuotedChars4 instead. ")
+
+  error-QuotedBracket4 =
+    debug(!"Unexpected constructor. Expected string from sort QuotedBracket4 instead. ")
+
+  error-Dollar4 =
+    debug(!"Unexpected constructor. Expected string from sort Dollar4 instead. ")
+
+  error-Padding =
+    debug(!"Unexpected constructor. Expected string from sort Padding instead. ")
+
+  error-PPTerm =
+    debug(!"Unexpected constructor. Expected constructor from sort PPTerm instead. ")

--- a/Xtext/nabl/src-gen/check/terms/Terms-chk.str
+++ b/Xtext/nabl/src-gen/check/terms/Terms-chk.str
@@ -1,0 +1,197 @@
+module nabl/src-gen/check/terms/Terms-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Constants-sig
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/check/terms/Constants-chk
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/terms/Vars-chk
+
+
+strategies
+  check-example =
+    check-Pattern
+
+  check-Pattern :
+    t1__ -> <id>
+    where not(is-Pattern-with-constructor)
+    where <(check-Var <+ error-Var)> t1__
+
+  check-Pattern :
+    Int(t1__) -> <id>
+    with <(check-Int <+ error-Int)> t1__
+
+  is-Pattern-with-constructor =
+    ?Int(_)
+
+  check-Pattern :
+    Real(t1__) -> <id>
+    with <(check-Real <+ error-Real)> t1__
+
+  is-Pattern-with-constructor =
+    ?Real(_)
+
+  check-Pattern :
+    Str(t1__) -> <id>
+    with <(check-String <+ error-String)> t1__
+
+  is-Pattern-with-constructor =
+    ?Str(_)
+
+  check-Pattern :
+    Op(t1__, t2__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+    with <map(check-Pattern <+ error-Pattern)> t2__
+
+  is-Pattern-with-constructor =
+    ?Op(_, _)
+
+  check-Pattern :
+    OpQ(t1__, t2__) -> <id>
+    with <(check-String <+ error-String)> t1__
+    with <map(check-Pattern <+ error-Pattern)> t2__
+
+  is-Pattern-with-constructor =
+    ?OpQ(_, _)
+
+  check-Pattern :
+    Char(t1__) -> <id>
+    with <(check-Char <+ error-Char)> t1__
+
+  is-Pattern-with-constructor =
+    ?Char(_)
+
+  check-Pattern :
+    Tuple(t1__) -> <id>
+    with <map(check-Pattern <+ error-Pattern)> t1__
+
+  is-Pattern-with-constructor =
+    ?Tuple(_)
+
+  check-Pattern :
+    List(t1__) -> <id>
+    with <map(check-Pattern <+ error-Pattern)> t1__
+
+  is-Pattern-with-constructor =
+    ?List(_)
+
+  check-Pattern :
+    ListTail(t1__, t2__) -> <id>
+    with <map(check-Pattern <+ error-Pattern)> t1__
+    with <(check-Pattern <+ error-Pattern)> t2__
+
+  is-Pattern-with-constructor =
+    ?ListTail(_, _)
+
+  check-Pattern :
+    As(t1__, t2__) -> <id>
+    with <(check-Var <+ error-Var)> t1__
+    with <(check-Pattern <+ error-Pattern)> t2__
+
+  is-Pattern-with-constructor =
+    ?As(_, _)
+
+  is-Pattern-with-constructor =
+    fail
+
+  check-Pattern :
+    amb([h|hs]) -> <check-Pattern> h
+
+  error-Pattern =
+    debug(!"Unexpected constructor. Expected constructor from sort Pattern instead. ")
+
+
+strategies
+  check-example =
+    check-Term
+
+  check-Term :
+    t1__ -> <id>
+    where not(is-Term-with-constructor)
+    where <(check-VarRef <+ error-VarRef)> t1__
+
+  check-Term :
+    Int(t1__) -> <id>
+    with <(check-Int <+ error-Int)> t1__
+
+  is-Term-with-constructor =
+    ?Int(_)
+
+  check-Term :
+    Real(t1__) -> <id>
+    with <(check-Real <+ error-Real)> t1__
+
+  is-Term-with-constructor =
+    ?Real(_)
+
+  check-Term :
+    Str(t1__) -> <id>
+    with <(check-String <+ error-String)> t1__
+
+  is-Term-with-constructor =
+    ?Str(_)
+
+  check-Term :
+    Op(t1__, t2__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+    with <map(check-Term <+ error-Term)> t2__
+
+  is-Term-with-constructor =
+    ?Op(_, _)
+
+  check-Term :
+    OpQ(t1__, t2__) -> <id>
+    with <(check-String <+ error-String)> t1__
+    with <map(check-Term <+ error-Term)> t2__
+
+  is-Term-with-constructor =
+    ?OpQ(_, _)
+
+  check-Term :
+    Char(t1__) -> <id>
+    with <(check-Char <+ error-Char)> t1__
+
+  is-Term-with-constructor =
+    ?Char(_)
+
+  check-Term :
+    Tuple(t1__) -> <id>
+    with <map(check-Term <+ error-Term)> t1__
+
+  is-Term-with-constructor =
+    ?Tuple(_)
+
+  check-Term :
+    List(t1__) -> <id>
+    with <map(check-Term <+ error-Term)> t1__
+
+  is-Term-with-constructor =
+    ?List(_)
+
+  check-Term :
+    ListTail(t1__, t2__) -> <id>
+    with <map(check-Term <+ error-Term)> t1__
+    with <(check-Term <+ error-Term)> t2__
+
+  is-Term-with-constructor =
+    ?ListTail(_, _)
+
+  is-Term-with-constructor =
+    fail
+
+  check-Term :
+    amb([h|hs]) -> <check-Term> h
+
+  error-Term =
+    debug(!"Unexpected constructor. Expected constructor from sort Term instead. ")

--- a/Xtext/nabl/src-gen/check/terms/Vars-chk.str
+++ b/Xtext/nabl/src-gen/check/terms/Vars-chk.str
@@ -1,0 +1,94 @@
+module nabl/src-gen/check/terms/Vars-chk
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/check/common/Identifiers-chk
+  nabl/src-gen/check/terms/Terms-chk
+
+
+strategies
+  check-example =
+    check-Wld
+
+  check-example =
+    check-Var
+
+  check-example =
+    check-VarRef
+
+  check-Wld :
+    Wld() -> <id>
+
+  is-Wld-with-constructor =
+    ?Wld()
+
+  check-Var :
+    t1__ -> <id>
+    where not(is-Var-with-constructor)
+    where <(check-Wld <+ error-Wld)> t1__
+
+  check-Var :
+    Var(t1__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+
+  is-Var-with-constructor =
+    ?Var(_)
+
+  check-Var :
+    ListVar(t1__) -> <id>
+    with <(check-LId <+ error-LId)> t1__
+
+  is-Var-with-constructor =
+    ?ListVar(_)
+
+  check-VarRef :
+    VarRef(t1__) -> <id>
+    with <(check-Id <+ error-Id)> t1__
+
+  is-VarRef-with-constructor =
+    ?VarRef(_)
+
+  check-VarRef :
+    ListVarRef(t1__) -> <id>
+    with <(check-LId <+ error-LId)> t1__
+
+  is-VarRef-with-constructor =
+    ?ListVarRef(_)
+
+  is-Wld-with-constructor =
+    fail
+
+  is-Var-with-constructor =
+    fail
+
+  is-VarRef-with-constructor =
+    fail
+
+  check-Wld :
+    amb([h|hs]) -> <check-Wld> h
+
+  check-Var :
+    amb([h|hs]) -> <check-Var> h
+
+  check-VarRef :
+    amb([h|hs]) -> <check-VarRef> h
+
+  error-Wld =
+    debug(!"Unexpected constructor. Expected constructor from sort Wld instead. ")
+
+  error-Var =
+    debug(!"Unexpected constructor. Expected constructor from sort Var instead. ")
+
+  error-VarRef =
+    debug(!"Unexpected constructor. Expected constructor from sort VarRef instead. ")

--- a/Xtext/nabl/src-gen/completions/NameBindingLanguage-esv.esv
+++ b/Xtext/nabl/src-gen/completions/NameBindingLanguage-esv.esv
@@ -1,0 +1,97 @@
+module nabl/src-gen/completions/NameBindingLanguage-esv
+
+imports
+  nabl/src-gen/completions/common/Layout-esv
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/terms/Signatures-esv
+  nabl/src-gen/completions/terms/Terms-esv
+  nabl/src-gen/completions/formulas/Formulas-esv
+  nabl/src-gen/completions/formulas/Propositions-esv
+  nabl/src-gen/completions/core/Modules-esv
+  nabl/src-gen/completions/core/Namespaces-esv
+  nabl/src-gen/completions/core/Properties-esv
+  nabl/src-gen/completions/terms/Vars-esv
+
+completions
+  completion template RestrictedNamespaceRef : " NamespaceRef" =
+    <:Restriction> " " <NamespaceRef:NamespaceRef>  
+  completion template Restriction : "imported" =
+    "imported"  
+
+completions
+  completion template PropertyDef : "PropertyID of NamespaceRef" =
+    <PropertyID:PropertyID> " of " <NamespaceRef:NamespaceRef> (blank)  
+  completion template PropertyTerm : "of PropertyRef Term" =
+    "of " <PropertyRef:PropertyRef> " " <Term:Term>  
+  completion template PropertyTerm : "of quality QualityRef" =
+    "of quality " <QualityRef:QualityRef>  
+  completion template PropertyPattern : "of PropFilter PropertyRef Term" =
+    "of " <PropFilter:PropFilter> " " <PropertyRef:PropertyRef> " " <Term:Term>  
+  completion template PropertyPattern : "of quality QualityRef" =
+    "of quality " <QualityRef:QualityRef>  
+  completion template PropFilter : "conformant" =
+    "conformant"               
+
+completions
+  completion template ModuleSection : "binding rules " =
+    "binding rules\n\t" (cursor) (blank)  
+  completion template BindingRule : "Pattern Constraints : BindingClause" =
+    <Pattern:Pattern> " " <Constraints:Constraints> " : " <BindingClause:BindingClause> (blank)  
+
+completions
+  completion template BindingClause : "DefKind defines Unique NamespaceRef Term InDefScopes Constraints" =
+    <DefKind:DefKind> " defines " <Unique:Unique> " " <NamespaceRef:NamespaceRef> " " <Term:Term> " " <:PropertyTerm> " " <InDefScopes:InDefScopes> " " <Constraints:Constraints> (blank)  
+  completion template DefKind : "implicitly" =
+    "implicitly"                                                                                                                                                                                
+  completion template Unique : "unique" =
+    "unique"                                                                                                                                                                                         
+  completion template Unique : "non-unique" =
+    "non-unique"                                                                                                                                                                                 
+  completion template BindingClause : "scopes NamespaceRef" =
+    "scopes " <NamespaceRef:NamespaceRef> (blank)                                                                                                                                
+  completion template BindingClause : "non-transitively scopes NamespaceRef" =
+    "non-transitively scopes " <NamespaceRef:NamespaceRef> (blank)                                                                                              
+  completion template RefClausePart : "refers to Disambiguator NamespaceRef Term InRefScope Constraints" =
+    "refers to " <Disambiguator:Disambiguator> " " <NamespaceRef:NamespaceRef> " " <Term:Term> " " <:PropertyPattern> " " <InRefScope:InRefScope> " " <Constraints:Constraints> (blank)  
+  completion template ImportClausePart : "imports Disambiguator NamespaceRef Term FromRefScope Alias IntoDefScopes Constraints" =
+    "imports " <Disambiguator:Disambiguator> " " <NamespaceRef:NamespaceRef> " " <Term:Term> " " <:PropertyPattern> " " <FromRefScope:FromRefScope> " " <Alias:Alias> " " <IntoDefScopes:IntoDefScopes> " " <Constraints:Constraints> (blank)  
+  completion template ImportClausePart : "imports RestrictedNamespaceRef FromRefScope IntoDefScopes Constraints" =
+    "imports " <RestrictedNamespaceRef:RestrictedNamespaceRef> " " <:PropertyPattern> " " <FromRefScope:FromRefScope> " " <IntoDefScopes:IntoDefScopes> " " <Constraints:Constraints> (blank)  
+  completion template Alias : "as Term" =
+    "as " <Term:Term>                                                                                                                                                                                
+  completion template BindingClause : "filters NamespaceRef Term Filters Constraints" =
+    "filters " <NamespaceRef:NamespaceRef> " " <Term:Term> "\n\t" <Filters:Filters> "\n\t" <Constraints:Constraints> (blank)                           
+  completion template BindingClause : "disambiguates NamespaceRef Term Filters by Disambiguator Constraints" =
+    "disambiguates " <NamespaceRef:NamespaceRef> " " <Term:Term> "\n\t" <Filters:Filters> "\n\tby " <Disambiguator:Disambiguator> "\n\t" <Constraints:Constraints> (blank)  
+  completion template Disambiguator : "minimal distance Term Relation Term" =
+    "minimal distance " <Term:Term> " " <Relation:Relation> " " <Term:Term> (blank)                                                                              
+
+completions
+  completion template InDefScopes : "in DefScopes" =
+    "in " <DefScopes:DefScopes>                                                  
+  completion template IntoDefScopes : "into DefScopes" =
+    "into " <DefScopes:DefScopes>                                            
+  completion template DefScopes : "current scope" =
+    "current scope"                                                               
+  completion template DefScope : "subsequent scope" =
+    "subsequent scope"                                                          
+  completion template InRefScope : "in RefScope" =
+    "in " <RefScope:RefScope>                                                      
+  completion template FromRefScope : "from RefScope" =
+    "from " <RefScope:RefScope>                                                
+  completion template RefScope : "current scope" =
+    "current scope"                                                                
+  completion template RefScope : "enclosing NamespaceRef" =
+    "enclosing " <NamespaceRef:NamespaceRef>                              
+  completion template RefScope : "Disambiguator NamespaceRef Term InRefScope" =
+    <Disambiguator:Disambiguator> " " <NamespaceRef:NamespaceRef> " " <Term:Term> " " <:PropertyPattern> " " <InRefScope:InRefScope>  
+  completion template Disambiguator : "best" =
+    "best"                                                                             
+
+completions
+  completion template Constraints : "where Formula" =
+    "where " <Formula:Formula> (blank)  
+  completion template Filters : "with Formula" =
+    "with " <Formula:Formula> (blank)  
+  completion template Proposition : "VarRef has PropertyRef Pattern" =
+    <VarRef:VarRef> " has " <PropertyRef:PropertyRef> " " <Pattern:Pattern>  

--- a/Xtext/nabl/src-gen/completions/common/Identifiers-esv.esv
+++ b/Xtext/nabl/src-gen/completions/common/Identifiers-esv.esv
@@ -1,0 +1,1 @@
+module nabl/src-gen/completions/common/Identifiers-esv

--- a/Xtext/nabl/src-gen/completions/common/Layout-esv.esv
+++ b/Xtext/nabl/src-gen/completions/common/Layout-esv.esv
@@ -1,0 +1,1 @@
+module nabl/src-gen/completions/common/Layout-esv

--- a/Xtext/nabl/src-gen/completions/core/Modules-esv.esv
+++ b/Xtext/nabl/src-gen/completions/core/Modules-esv.esv
@@ -1,0 +1,9 @@
+module nabl/src-gen/completions/core/Modules-esv
+
+completions
+  completion template Module : "module ModuleID " =
+    "module " <ModuleID:ModuleID> "\n\n\t\t" (cursor) (blank)  
+  completion template ModuleSection : "imports " =
+    "imports " <:ImportModule> (blank)  
+  completion template ImportModule : "ModuleID/-" =
+    <ModuleID:ModuleID> "/-"  

--- a/Xtext/nabl/src-gen/completions/core/Namespaces-esv.esv
+++ b/Xtext/nabl/src-gen/completions/core/Namespaces-esv.esv
@@ -1,0 +1,13 @@
+module nabl/src-gen/completions/core/Namespaces-esv
+
+imports
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/core/Modules-esv
+
+completions
+  completion template ModuleSection : "namespaces " =
+    "namespaces\n\t" (cursor) (blank)  
+  completion template NamespaceRef : "LanguageRefNamespaceID" =
+    <LanguageRef:LanguageRef> <NamespaceID:NamespaceID>  
+  completion template LanguageRef : "Id." =
+    <Id:Id> "."  

--- a/Xtext/nabl/src-gen/completions/core/Properties-esv.esv
+++ b/Xtext/nabl/src-gen/completions/core/Properties-esv.esv
@@ -1,0 +1,18 @@
+
+module nabl/src-gen/completions/core/Properties-esv
+
+imports
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/terms/Signatures-esv
+  nabl/src-gen/completions/terms/Vars-esv
+  nabl/src-gen/completions/terms/Terms-esv
+  nabl/src-gen/completions/formulas/Formulas-esv
+  nabl/src-gen/completions/core/Namespaces-esv
+
+completions
+  completion template ModuleSection : "properties " =
+    "properties\n\t" (cursor) (blank)  
+  completion template PropertyDef : "PropertyID of NamespaceRef : Sort" =
+    <PropertyID:PropertyID> " of " <NamespaceRef:NamespaceRef> " : " <Sort:Sort> (blank)  
+  completion template PropertyRef : "type" =
+    "type"                                   

--- a/Xtext/nabl/src-gen/completions/core/Scopes-esv.esv
+++ b/Xtext/nabl/src-gen/completions/core/Scopes-esv.esv
@@ -1,0 +1,29 @@
+
+module nabl/src-gen/completions/core/Scopes-esv
+
+imports
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/core/Namespaces-esv
+  nabl/src-gen/completions/terms/Vars-esv
+
+completions
+  completion template LocalScope : "NamespaceRef VarRef" =
+    <NamespaceRef:NamespaceRef> " " <VarRef:VarRef>  
+  completion template LocalScope : "current NamespaceRef scope" =
+    "current " <NamespaceRef:NamespaceRef> " scope"  
+  completion template LocalScope : "NamespaceRef scope at VarRef" =
+    <NamespaceRef:NamespaceRef> " scope  at " <VarRef:VarRef>  
+  completion template LocalScope : "enclosing NamespaceRef of LocalScope" =
+    "enclosing " <NamespaceRef:NamespaceRef> " of " <LocalScope:LocalScope>  
+  completion template Scope : "global scope" =
+    "global scope"            
+  completion template Scope : "new scope in Scope" =
+    "new scope in " <Scope:Scope>  
+
+completions
+  completion template Clause : "Scope scopes NamespaceRef at child nodes" =
+    <Scope:Scope> " scopes " <NamespaceRef:NamespaceRef> " at child nodes" (blank)  
+  completion template Clause : "Scope scopes NamespaceRef at subsequent nodes" =
+    <Scope:Scope> " scopes " <NamespaceRef:NamespaceRef> " at subsequent nodes" (blank)  
+  completion template Clause : "requires NamespaceRef scope at VarRef" =
+    "requires " <NamespaceRef:NamespaceRef> " scope at " <VarRef:VarRef> (blank)  

--- a/Xtext/nabl/src-gen/completions/formulas/Formulas-esv.esv
+++ b/Xtext/nabl/src-gen/completions/formulas/Formulas-esv.esv
@@ -1,0 +1,15 @@
+module nabl/src-gen/completions/formulas/Formulas-esv
+
+imports
+  nabl/src-gen/completions/terms/Terms-esv
+  nabl/src-gen/completions/formulas/Propositions-esv
+
+completions
+  completion template Formula : "not Formula" =
+    "not " <Formula:Formula> (blank)  
+  completion template Formula : "Formula and Formula" =
+    <Formula:Formula> "\nand " <Formula:Formula> (blank)  
+  completion template Formula : "Formula or Formula" =
+    <Formula:Formula> "\nor " <Formula:Formula> (blank)  
+  completion template Formula : "(Formula)" =
+    "(" <Formula:Formula> ")"  

--- a/Xtext/nabl/src-gen/completions/formulas/Messages-esv.esv
+++ b/Xtext/nabl/src-gen/completions/formulas/Messages-esv.esv
@@ -1,0 +1,14 @@
+module nabl/src-gen/completions/formulas/Messages-esv
+
+imports
+  nabl/src-gen/completions/terms/Terms-esv
+
+completions
+  completion template Message : "MessageKind Term on Term" =
+    <MessageKind:MessageKind> " " <Term:Term> " on " <Term:Term>  
+  completion template MessageKind : "error" =
+    "error"         
+  completion template MessageKind : "warning" =
+    "warning"     
+  completion template MessageKind : "note" =
+    "note"           

--- a/Xtext/nabl/src-gen/completions/formulas/Propositions-esv.esv
+++ b/Xtext/nabl/src-gen/completions/formulas/Propositions-esv.esv
@@ -1,0 +1,31 @@
+
+module nabl/src-gen/completions/formulas/Propositions-esv
+
+imports
+  nabl/src-gen/completions/terms/Terms-esv
+  nabl/src-gen/completions/terms/Vars-esv
+  nabl/src-gen/completions/core/Namespaces-esv
+  nabl/src-gen/completions/core/Scopes-esv
+  nabl/src-gen/completions/core/Properties-esv
+
+completions
+  completion template Proposition : "true" =
+    "true"                                
+  completion template Proposition : "false" =
+    "false"                              
+  completion template Proposition : "VarRef == Term" =
+    <VarRef:VarRef> " == " <Term:Term>  
+  completion template Proposition : "VarRef => Pattern" =
+    <VarRef:VarRef> " => " <Pattern:Pattern>  
+  completion template Proposition : "definition of VarRef => Var" =
+    "definition of " <VarRef:VarRef> " => " <Var:Var>  
+  completion template Proposition : "definition of NamespaceRef VarRef => Var" =
+    "definition of " <NamespaceRef:NamespaceRef> " " <VarRef:VarRef> " => " <Var:Var>  
+  completion template Proposition : "Scope => Var" =
+    <Scope:Scope> " => " <Var:Var>  
+  completion template Proposition : "Term resolves to NamespaceRef Var" =
+    <Term:Term> " resolves to " <NamespaceRef:NamespaceRef> " " <Var:Var>  
+  completion template Proposition : "VarRef has PropertyRef Var" =
+    <VarRef:VarRef> " has " <PropertyRef:PropertyRef> " " <Var:Var>  
+  completion template Proposition : "Term Relation Term" =
+    <Term:Term> " " <Relation:Relation> " " <Term:Term>  

--- a/Xtext/nabl/src-gen/completions/lexical/Identifiers-esv.esv
+++ b/Xtext/nabl/src-gen/completions/lexical/Identifiers-esv.esv
@@ -1,0 +1,1 @@
+module nabl/src-gen/completions/lexical/Identifiers-esv

--- a/Xtext/nabl/src-gen/completions/lexical/Layout-esv.esv
+++ b/Xtext/nabl/src-gen/completions/lexical/Layout-esv.esv
@@ -1,0 +1,1 @@
+module nabl/src-gen/completions/lexical/Layout-esv

--- a/Xtext/nabl/src-gen/completions/terms/Constants-esv.esv
+++ b/Xtext/nabl/src-gen/completions/terms/Constants-esv.esv
@@ -1,0 +1,1 @@
+module nabl/src-gen/completions/terms/Constants-esv

--- a/Xtext/nabl/src-gen/completions/terms/Signatures-esv.esv
+++ b/Xtext/nabl/src-gen/completions/terms/Signatures-esv.esv
@@ -1,0 +1,21 @@
+module nabl/src-gen/completions/terms/Signatures-esv
+
+imports
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/terms/Constants-esv
+
+completions
+  completion template Sort : "Id ( )" =
+    <Id:Id> " ( " <:Sort> " )"  
+
+completions
+  completion template TypeDecl : "Id TypeParams PPTerm" =
+    <Id:Id> " " <TypeParams:TypeParams> " " <PPTerm:PPTerm>  
+  completion template TypeDecl : "String TypeParams PPTerm" =
+    <String:String> " " <TypeParams:TypeParams> " " <PPTerm:PPTerm>  
+
+completions
+  completion template TypeParams : "( TypeParam )" =
+    "( " <TypeParam:TypeParam> " )"  
+  completion template TypeParam : "Id : Sort" =
+    <Id:Id> " : " <Sort:Sort>  

--- a/Xtext/nabl/src-gen/completions/terms/StringQuotations-esv.esv
+++ b/Xtext/nabl/src-gen/completions/terms/StringQuotations-esv.esv
@@ -1,0 +1,4 @@
+module nabl/src-gen/completions/terms/StringQuotations-esv
+
+imports
+  nabl/src-gen/completions/terms/Terms-esv

--- a/Xtext/nabl/src-gen/completions/terms/Terms-esv.esv
+++ b/Xtext/nabl/src-gen/completions/terms/Terms-esv.esv
@@ -1,0 +1,32 @@
+module nabl/src-gen/completions/terms/Terms-esv
+
+imports
+  nabl/src-gen/completions/terms/Constants-esv
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/terms/Vars-esv
+
+completions
+  completion template Pattern : "Id()" =
+    <Id:Id> "(" <:Pattern> ")"  
+  completion template Pattern : "String()" =
+    <String:String> "(" <:Pattern> ")"  
+  completion template Pattern : "()" =
+    "(" <:Pattern> ")"  
+  completion template Pattern : "[]" =
+    "[" <:Pattern> "]"  
+  completion template Pattern : "[ | Pattern]" =
+    "[" <:Pattern> " | " <Pattern:Pattern> "]"  
+  completion template Pattern : "Var@Pattern" =
+    <Var:Var> "@" <Pattern:Pattern>  
+
+completions
+  completion template Term : "Id()" =
+    <Id:Id> "(" <:Term> ")"  
+  completion template Term : "String()" =
+    <String:String> "(" <:Term> ")"  
+  completion template Term : "()" =
+    "(" <:Term> ")"  
+  completion template Term : "[]" =
+    "[" <:Term> "]"  
+  completion template Term : "[ | Term]" =
+    "[" <:Term> " | " <Term:Term> "]"  

--- a/Xtext/nabl/src-gen/completions/terms/Vars-esv.esv
+++ b/Xtext/nabl/src-gen/completions/terms/Vars-esv.esv
@@ -1,0 +1,9 @@
+module nabl/src-gen/completions/terms/Vars-esv
+
+imports
+  nabl/src-gen/completions/common/Identifiers-esv
+  nabl/src-gen/completions/terms/Terms-esv
+
+completions
+  completion template Wld : "_" =
+    "_"  

--- a/Xtext/nabl/src-gen/pp/NameBindingLanguage-pp.str
+++ b/Xtext/nabl/src-gen/pp/NameBindingLanguage-pp.str
@@ -1,0 +1,1028 @@
+module nabl/src-gen/pp/NameBindingLanguage-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/NameBindingLanguage-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Layout-sig
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Signatures-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Formulas-sig
+  nabl/src-gen/signatures/formulas/Propositions-sig
+  nabl/src-gen/signatures/core/Modules-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/core/Properties-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/pp/common/Layout-pp
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/terms/Signatures-pp
+  nabl/src-gen/pp/terms/Terms-pp
+  nabl/src-gen/pp/formulas/Formulas-pp
+  nabl/src-gen/pp/formulas/Propositions-pp
+  nabl/src-gen/pp/core/Modules-pp
+  nabl/src-gen/pp/core/Namespaces-pp
+  nabl/src-gen/pp/core/Properties-pp
+  nabl/src-gen/pp/terms/Vars-pp
+
+
+strategies
+  prettyprint-SDF-start-symbols =
+    prettyprint-Start
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Start
+
+  prettyprint-Start :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Start)
+    where t1__' := <pp-one-Z(prettyprint-nabl-Module)> t1__
+
+  is-Start =
+    fail
+
+  prettyprint-Start :
+    amb([h|hs]) -> <prettyprint-Start> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-RestrictedNamespaceRef
+
+  prettyprint-example =
+    prettyprint-Restriction
+
+  prettyprint-RestrictedNamespaceRef :
+    Restricted(t1__, t2__) -> [ H(
+                                  [SOpt(HS(), "0")]
+                                , [t1__', S(" "), t2__']
+                                )
+                              ]
+    with t1__' := <pp-H-list(prettyprint-Restriction)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+
+  is-RestrictedNamespaceRef =
+    ?Restricted(_, _)
+
+  prettyprint-Restriction :
+    Imported() -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [S("imported")]
+                    )
+                  ]
+
+  is-Restriction =
+    ?Imported()
+
+  is-RestrictedNamespaceRef =
+    fail
+
+  is-Restriction =
+    fail
+
+  prettyprint-RestrictedNamespaceRef :
+    amb([h|hs]) -> <prettyprint-RestrictedNamespaceRef> h
+
+  prettyprint-Restriction :
+    amb([h|hs]) -> <prettyprint-Restriction> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-PropertyDef
+
+  prettyprint-example =
+    prettyprint-QualityRef
+
+  prettyprint-example =
+    prettyprint-PropertyTerm
+
+  prettyprint-example =
+    prettyprint-PropertyPattern
+
+  prettyprint-example =
+    prettyprint-PropFilter
+
+  prettyprint-PropertyDef :
+    QualityDef(t1__, t2__) -> [ H(
+                                  [SOpt(HS(), "0")]
+                                , [t1__', S(" of "), t2__']
+                                )
+                              ]
+    with t1__' := <pp-one-Z(prettyprint-PropertyID)> t1__
+    with t2__' := <pp-H-list(prettyprint-NamespaceRef|", ")> t2__
+
+  is-PropertyDef =
+    ?QualityDef(_, _)
+
+  prettyprint-QualityRef :
+    QualityRef(t1__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [t1__']
+                          )
+                        ]
+    with t1__' := <pp-one-Z(prettyprint-PropertyID)> t1__
+
+  is-QualityRef =
+    ?QualityRef(_)
+
+  prettyprint-PropertyTerm :
+    PropertyTerm(t1__, t2__) -> [ H(
+                                    [SOpt(HS(), "0")]
+                                  , [ S("of ")
+                                    , t1__'
+                                    , S(" ")
+                                    , t2__'
+                                    ]
+                                  )
+                                ]
+    with t1__' := <pp-one-Z(prettyprint-PropertyRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Term)> t2__
+
+  is-PropertyTerm =
+    ?PropertyTerm(_, _)
+
+  prettyprint-PropertyTerm :
+    QualityTerm(t1__) -> [ H(
+                             [SOpt(HS(), "0")]
+                           , [S("of quality "), t1__']
+                           )
+                         ]
+    with t1__' := <pp-one-Z(prettyprint-QualityRef)> t1__
+
+  is-PropertyTerm =
+    ?QualityTerm(_)
+
+  prettyprint-PropertyPattern :
+    PropertyPattern(t1__, t2__, t3__) -> [ H(
+                                             [SOpt(HS(), "0")]
+                                           , [ S("of ")
+                                             , t1__'
+                                             , S(" ")
+                                             , t2__'
+                                             , S(" ")
+                                             , t3__'
+                                             ]
+                                           )
+                                         ]
+    with t1__' := <pp-one-Z(prettyprint-PropFilter)> t1__
+    with t2__' := <pp-one-Z(prettyprint-PropertyRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+
+  is-PropertyPattern =
+    ?PropertyPattern(_, _, _)
+
+  prettyprint-PropertyPattern :
+    QualityPattern(t1__) -> [ H(
+                                [SOpt(HS(), "0")]
+                              , [S("of quality "), t1__']
+                              )
+                            ]
+    with t1__' := <pp-one-Z(prettyprint-QualityRef)> t1__
+
+  is-PropertyPattern =
+    ?QualityPattern(_)
+
+  prettyprint-PropFilter :
+    Equal() -> [ H(
+                   []
+                 , [S("")]
+                 )
+               ]
+
+  is-PropFilter =
+    ?Equal()
+
+  prettyprint-PropFilter :
+    Conformant() -> [ H(
+                        [SOpt(HS(), "0")]
+                      , [S("conformant")]
+                      )
+                    ]
+
+  is-PropFilter =
+    ?Conformant()
+
+  is-PropertyDef =
+    fail
+
+  is-QualityRef =
+    fail
+
+  is-PropertyTerm =
+    fail
+
+  is-PropertyPattern =
+    fail
+
+  is-PropFilter =
+    fail
+
+  prettyprint-PropertyDef :
+    amb([h|hs]) -> <prettyprint-PropertyDef> h
+
+  prettyprint-QualityRef :
+    amb([h|hs]) -> <prettyprint-QualityRef> h
+
+  prettyprint-PropertyTerm :
+    amb([h|hs]) -> <prettyprint-PropertyTerm> h
+
+  prettyprint-PropertyPattern :
+    amb([h|hs]) -> <prettyprint-PropertyPattern> h
+
+  prettyprint-PropFilter :
+    amb([h|hs]) -> <prettyprint-PropFilter> h
+
+
+strategies
+  prettyprint-SectionKeyword =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-SectionKeyword
+
+  prettyprint-SectionKeyword :
+    amb([h|hs]) -> <prettyprint-SectionKeyword> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-nabl-ModuleSection
+
+  prettyprint-example =
+    prettyprint-BindingRule
+
+  prettyprint-nabl-ModuleSection :
+    Bindings(t1__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [S("binding rules")]
+                        )
+                      , t1__'
+                      ]
+    with t1__' := <pp-indent(|"2")> [<pp-H-list(prettyprint-BindingRule)> t1__]
+
+  is-ModuleSection =
+    ?Bindings(_)
+
+  prettyprint-BindingRule :
+    BindingRule(t1__, t2__, t3__) -> [ H(
+                                         [SOpt(HS(), "0")]
+                                       , [ t1__'
+                                         , S(" ")
+                                         , t2__'
+                                         , S(" : ")
+                                         , t3__'
+                                         ]
+                                       )
+                                     ]
+    with t1__' := <pp-one-Z(prettyprint-Pattern)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Constraints)> t2__
+    with t3__' := <pp-H-list(prettyprint-BindingClause)> t3__
+
+  is-BindingRule =
+    ?BindingRule(_, _, _)
+
+  is-ModuleSection =
+    fail
+
+  is-BindingRule =
+    fail
+
+  prettyprint-nabl-ModuleSection :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleSection> h
+
+  prettyprint-BindingRule :
+    amb([h|hs]) -> <prettyprint-BindingRule> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-DefKind
+
+  prettyprint-example =
+    prettyprint-Unique
+
+  prettyprint-example =
+    prettyprint-RefClausePart
+
+  prettyprint-example =
+    prettyprint-ImportClausePart
+
+  prettyprint-example =
+    prettyprint-Alias
+
+  prettyprint-example =
+    prettyprint-BindingClause
+
+  prettyprint-example =
+    prettyprint-Disambiguator
+
+  prettyprint-BindingClause :
+    DefClause(
+      t1__
+    , t2__
+    , t3__
+    , t4__
+    , t5__
+    , t6__
+    , t7__
+    ) -> [ H(
+             [SOpt(HS(), "0")]
+           , [ t1__'
+             , S(" defines ")
+             , t2__'
+             , S(" ")
+             , t3__'
+             , S(" ")
+             , t4__'
+             , S(" ")
+             , t5__'
+             , S(" ")
+             , t6__'
+             , S(" ")
+             , t7__'
+             ]
+           )
+         ]
+    with t1__' := <pp-one-Z(prettyprint-DefKind)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Unique)> t2__
+    with t3__' := <pp-one-Z(prettyprint-NamespaceRef)> t3__
+    with t4__' := <pp-one-Z(prettyprint-Term)> t4__
+    with t5__' := <pp-H-list(prettyprint-PropertyTerm)> t5__
+    with t6__' := <pp-one-Z(prettyprint-InDefScopes)> t6__
+    with t7__' := <pp-one-Z(prettyprint-Constraints)> t7__
+
+  is-BindingClause =
+    ?DefClause(_, _, _, _, _, _, _)
+
+  prettyprint-DefKind :
+    Explicit() -> [ H(
+                      []
+                    , [S("")]
+                    )
+                  ]
+
+  is-DefKind =
+    ?Explicit()
+
+  prettyprint-DefKind :
+    Implicit() -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [S("implicitly")]
+                    )
+                  ]
+
+  is-DefKind =
+    ?Implicit()
+
+  prettyprint-Unique :
+    Unique() -> [ H(
+                    []
+                  , [S("")]
+                  )
+                ]
+
+  is-Unique =
+    ?Unique()
+
+  prettyprint-Unique :
+    Unique() -> [ H(
+                    [SOpt(HS(), "0")]
+                  , [S("unique")]
+                  )
+                ]
+
+  is-Unique =
+    ?Unique()
+
+  prettyprint-Unique :
+    NonUnique() -> [ H(
+                       [SOpt(HS(), "0")]
+                     , [S("non-unique")]
+                     )
+                   ]
+
+  is-Unique =
+    ?NonUnique()
+
+  prettyprint-BindingClause :
+    ScopeClause(t1__) -> [ H(
+                             [SOpt(HS(), "0")]
+                           , [S("scopes "), t1__']
+                           )
+                         ]
+    with t1__' := <pp-H-list(prettyprint-NamespaceRef|", ")> t1__
+
+  is-BindingClause =
+    ?ScopeClause(_)
+
+  prettyprint-BindingClause :
+    NonTransitiveScopeClause(t1__) -> [ H(
+                                          [SOpt(HS(), "0")]
+                                        , [S("non-transitively scopes "), t1__']
+                                        )
+                                      ]
+    with t1__' := <pp-H-list(prettyprint-NamespaceRef|", ")> t1__
+
+  is-BindingClause =
+    ?NonTransitiveScopeClause(_)
+
+  prettyprint-BindingClause :
+    RefClause(t1__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [t1__']
+                         )
+                       ]
+    with t1__' := <pp-H-list(prettyprint-RefClausePart|"otherwise")> t1__
+
+  is-BindingClause =
+    ?RefClause(_)
+
+  prettyprint-RefClausePart :
+    RefClausePart(t1__, t2__, t3__, t4__, t5__, t6__) -> [ H(
+                                                             [SOpt(HS(), "0")]
+                                                           , [ S("refers to ")
+                                                             , t1__'
+                                                             , S(" ")
+                                                             , t2__'
+                                                             , S(" ")
+                                                             , t3__'
+                                                             , S(" ")
+                                                             , t4__'
+                                                             , S(" ")
+                                                             , t5__'
+                                                             , S(" ")
+                                                             , t6__'
+                                                             ]
+                                                           )
+                                                         ]
+    with t1__' := <pp-one-Z(prettyprint-Disambiguator)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+    with t4__' := <pp-H-list(prettyprint-PropertyPattern)> t4__
+    with t5__' := <pp-one-Z(prettyprint-InRefScope)> t5__
+    with t6__' := <pp-one-Z(prettyprint-Constraints)> t6__
+
+  is-RefClausePart =
+    ?RefClausePart(_, _, _, _, _, _)
+
+  prettyprint-BindingClause :
+    ImportClause(t1__) -> [ H(
+                              [SOpt(HS(), "0")]
+                            , [t1__']
+                            )
+                          ]
+    with t1__' := <pp-V-list(prettyprint-ImportClausePart|"0", "otherwise")> t1__
+
+  is-BindingClause =
+    ?ImportClause(_)
+
+  prettyprint-ImportClausePart :
+    SingleImport(
+      t1__
+    , t2__
+    , t3__
+    , t4__
+    , t5__
+    , t6__
+    , t7__
+    , t8__
+    ) -> [ H(
+             [SOpt(HS(), "0")]
+           , [ S("imports ")
+             , t1__'
+             , S(" ")
+             , t2__'
+             , S(" ")
+             , t3__'
+             , S(" ")
+             , t4__'
+             , S(" ")
+             , t5__'
+             , S(" ")
+             , t6__'
+             , S(" ")
+             , t7__'
+             , S(" ")
+             , t8__'
+             ]
+           )
+         ]
+    with t1__' := <pp-one-Z(prettyprint-Disambiguator)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+    with t4__' := <pp-H-list(prettyprint-PropertyPattern)> t4__
+    with t5__' := <pp-one-Z(prettyprint-FromRefScope)> t5__
+    with t6__' := <pp-one-Z(prettyprint-Alias)> t6__
+    with t7__' := <pp-one-Z(prettyprint-IntoDefScopes)> t7__
+    with t8__' := <pp-one-Z(prettyprint-Constraints)> t8__
+
+  is-ImportClausePart =
+    ?SingleImport(_, _, _, _, _, _, _, _)
+
+  prettyprint-ImportClausePart :
+    WildcardImport(t1__, t2__, t3__, t4__, t5__) -> [ H(
+                                                        [SOpt(HS(), "0")]
+                                                      , [ S("imports ")
+                                                        , t1__'
+                                                        , S(" ")
+                                                        , t2__'
+                                                        , S(" ")
+                                                        , t3__'
+                                                        , S(" ")
+                                                        , t4__'
+                                                        , S(" ")
+                                                        , t5__'
+                                                        ]
+                                                      )
+                                                    ]
+    with t1__' := <pp-H-list(prettyprint-RestrictedNamespaceRef|", ")> t1__
+    with t2__' := <pp-H-list(prettyprint-PropertyPattern)> t2__
+    with t3__' := <pp-one-Z(prettyprint-FromRefScope)> t3__
+    with t4__' := <pp-one-Z(prettyprint-IntoDefScopes)> t4__
+    with t5__' := <pp-one-Z(prettyprint-Constraints)> t5__
+
+  is-ImportClausePart =
+    ?WildcardImport(_, _, _, _, _)
+
+  prettyprint-Alias :
+    None() -> [ H(
+                  []
+                , [S("")]
+                )
+              ]
+
+  is-Alias =
+    ?None()
+
+  prettyprint-Alias :
+    Alias(t1__) -> [ H(
+                       [SOpt(HS(), "0")]
+                     , [S("as "), t1__']
+                     )
+                   ]
+    with t1__' := <pp-one-Z(prettyprint-Term)> t1__
+
+  is-Alias =
+    ?Alias(_)
+
+  prettyprint-BindingClause :
+    FilterClause(t1__, t2__, t3__, t4__) -> [ H(
+                                                [SOpt(HS(), "0")]
+                                              , [ S("filters ")
+                                                , t1__'
+                                                , S(" ")
+                                                , t2__'
+                                                ]
+                                              )
+                                            , t3__'
+                                            , t4__'
+                                            ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Term)> t2__
+    with t3__' := <pp-indent(|"2")> [<pp-one-Z(prettyprint-Filters)> t3__]
+    with t4__' := <pp-indent(|"2")> [<pp-one-Z(prettyprint-Constraints)> t4__]
+
+  is-BindingClause =
+    ?FilterClause(_, _, _, _)
+
+  prettyprint-BindingClause :
+    DisambiguateClause(t1__, t2__, t3__, t4__, t5__) -> [ H(
+                                                            [SOpt(HS(), "0")]
+                                                          , [ S("disambiguates ")
+                                                            , t1__'
+                                                            , S(" ")
+                                                            , t2__'
+                                                            ]
+                                                          )
+                                                        , t3__'
+                                                        , t4__'
+                                                        , t5__'
+                                                        ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Term)> t2__
+    with t3__' := <pp-indent(|"2")> [<pp-one-Z(prettyprint-Filters)> t3__]
+    with t4__' := <pp-indent(|"2")> [ S("by ")
+                                    , <pp-one-Z(prettyprint-Disambiguator)> t4__
+                                    ]
+    with t5__' := <pp-indent(|"2")> [<pp-one-Z(prettyprint-Constraints)> t5__]
+
+  is-BindingClause =
+    ?DisambiguateClause(_, _, _, _, _)
+
+  prettyprint-Disambiguator :
+    MinimalDistance(t1__, t2__, t3__) -> [ H(
+                                             [SOpt(HS(), "0")]
+                                           , [ S("minimal distance ")
+                                             , t1__'
+                                             , S(" ")
+                                             , t2__'
+                                             , S(" ")
+                                             , t3__'
+                                             ]
+                                           )
+                                         ]
+    with t1__' := <pp-one-Z(prettyprint-Term)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Relation)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+
+  is-Disambiguator =
+    ?MinimalDistance(_, _, _)
+
+  is-DefKind =
+    fail
+
+  is-Unique =
+    fail
+
+  is-RefClausePart =
+    fail
+
+  is-ImportClausePart =
+    fail
+
+  is-Alias =
+    fail
+
+  is-BindingClause =
+    fail
+
+  is-Disambiguator =
+    fail
+
+  prettyprint-DefKind :
+    amb([h|hs]) -> <prettyprint-DefKind> h
+
+  prettyprint-Unique :
+    amb([h|hs]) -> <prettyprint-Unique> h
+
+  prettyprint-RefClausePart :
+    amb([h|hs]) -> <prettyprint-RefClausePart> h
+
+  prettyprint-ImportClausePart :
+    amb([h|hs]) -> <prettyprint-ImportClausePart> h
+
+  prettyprint-Alias :
+    amb([h|hs]) -> <prettyprint-Alias> h
+
+  prettyprint-BindingClause :
+    amb([h|hs]) -> <prettyprint-BindingClause> h
+
+  prettyprint-Disambiguator :
+    amb([h|hs]) -> <prettyprint-Disambiguator> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-InDefScopes
+
+  prettyprint-example =
+    prettyprint-IntoDefScopes
+
+  prettyprint-example =
+    prettyprint-DefScopes
+
+  prettyprint-example =
+    prettyprint-DefScope
+
+  prettyprint-example =
+    prettyprint-InRefScope
+
+  prettyprint-example =
+    prettyprint-FromRefScope
+
+  prettyprint-example =
+    prettyprint-RefScope
+
+  prettyprint-example =
+    prettyprint-Disambiguator
+
+  prettyprint-InDefScopes :
+    Current() -> [ H(
+                     []
+                   , [S("")]
+                   )
+                 ]
+
+  is-InDefScopes =
+    ?Current()
+
+  prettyprint-InDefScopes :
+    Parenthetical(t1__) -> [ H(
+                               [SOpt(HS(), "0")]
+                             , [S("in "), t1__']
+                             )
+                           ]
+    with t1__' := <pp-one-Z(prettyprint-DefScopes)> t1__
+
+  prettyprint-IntoDefScopes :
+    Current() -> [ H(
+                     []
+                   , [S("")]
+                   )
+                 ]
+
+  is-IntoDefScopes =
+    ?Current()
+
+  prettyprint-IntoDefScopes :
+    Parenthetical(t1__) -> [ H(
+                               [SOpt(HS(), "0")]
+                             , [S("into "), t1__']
+                             )
+                           ]
+    with t1__' := <pp-one-Z(prettyprint-DefScopes)> t1__
+
+  prettyprint-DefScopes :
+    Current() -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [S("current scope")]
+                   )
+                 ]
+
+  is-DefScopes =
+    ?Current()
+
+  prettyprint-DefScopes :
+    DefScopes(t1__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [t1__']
+                         )
+                       ]
+    with t1__' := <pp-H-list(prettyprint-DefScope|", ")> t1__
+
+  is-DefScopes =
+    ?DefScopes(_)
+
+  prettyprint-DefScope :
+    Subsequent() -> [ H(
+                        [SOpt(HS(), "0")]
+                      , [S("subsequent scope")]
+                      )
+                    ]
+
+  is-DefScope =
+    ?Subsequent()
+
+  prettyprint-DefScope :
+    DefScope(t1__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [t1__']
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-Term)> t1__
+
+  is-DefScope =
+    ?DefScope(_)
+
+  prettyprint-InRefScope :
+    Current() -> [ H(
+                     []
+                   , [S("")]
+                   )
+                 ]
+
+  is-InRefScope =
+    ?Current()
+
+  prettyprint-InRefScope :
+    Parenthetical(t1__) -> [ H(
+                               [SOpt(HS(), "0")]
+                             , [S("in "), t1__']
+                             )
+                           ]
+    with t1__' := <pp-one-Z(prettyprint-RefScope)> t1__
+
+  prettyprint-FromRefScope :
+    Current() -> [ H(
+                     []
+                   , [S("")]
+                   )
+                 ]
+
+  is-FromRefScope =
+    ?Current()
+
+  prettyprint-FromRefScope :
+    Parenthetical(t1__) -> [ H(
+                               [SOpt(HS(), "0")]
+                             , [S("from "), t1__']
+                             )
+                           ]
+    with t1__' := <pp-one-Z(prettyprint-RefScope)> t1__
+
+  prettyprint-RefScope :
+    Current() -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [S("current scope")]
+                   )
+                 ]
+
+  is-RefScope =
+    ?Current()
+
+  prettyprint-RefScope :
+    Enclosing(t1__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [S("enclosing "), t1__']
+                         )
+                       ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+
+  is-RefScope =
+    ?Enclosing(_)
+
+  prettyprint-RefScope :
+    Context(t1__, t2__, t3__, t4__, t5__) -> [ H(
+                                                 [SOpt(HS(), "0")]
+                                               , [ t1__'
+                                                 , S(" ")
+                                                 , t2__'
+                                                 , S(" ")
+                                                 , t3__'
+                                                 , S(" ")
+                                                 , t4__'
+                                                 , S(" ")
+                                                 , t5__'
+                                                 ]
+                                               )
+                                             ]
+    with t1__' := <pp-one-Z(prettyprint-Disambiguator)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+    with t4__' := <pp-H-list(prettyprint-PropertyPattern)> t4__
+    with t5__' := <pp-one-Z(prettyprint-InRefScope)> t5__
+
+  is-RefScope =
+    ?Context(_, _, _, _, _)
+
+  prettyprint-RefScope :
+    RefScope(t1__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [t1__']
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-Term)> t1__
+
+  is-RefScope =
+    ?RefScope(_)
+
+  prettyprint-Disambiguator :
+    All() -> [ H(
+                 []
+               , [S("")]
+               )
+             ]
+
+  is-Disambiguator =
+    ?All()
+
+  prettyprint-Disambiguator :
+    Best() -> [ H(
+                  [SOpt(HS(), "0")]
+                , [S("best")]
+                )
+              ]
+
+  is-Disambiguator =
+    ?Best()
+
+  is-InDefScopes =
+    fail
+
+  is-IntoDefScopes =
+    fail
+
+  is-DefScopes =
+    fail
+
+  is-DefScope =
+    fail
+
+  is-InRefScope =
+    fail
+
+  is-FromRefScope =
+    fail
+
+  is-RefScope =
+    fail
+
+  is-Disambiguator =
+    fail
+
+  prettyprint-InDefScopes :
+    amb([h|hs]) -> <prettyprint-InDefScopes> h
+
+  prettyprint-IntoDefScopes :
+    amb([h|hs]) -> <prettyprint-IntoDefScopes> h
+
+  prettyprint-DefScopes :
+    amb([h|hs]) -> <prettyprint-DefScopes> h
+
+  prettyprint-DefScope :
+    amb([h|hs]) -> <prettyprint-DefScope> h
+
+  prettyprint-InRefScope :
+    amb([h|hs]) -> <prettyprint-InRefScope> h
+
+  prettyprint-FromRefScope :
+    amb([h|hs]) -> <prettyprint-FromRefScope> h
+
+  prettyprint-RefScope :
+    amb([h|hs]) -> <prettyprint-RefScope> h
+
+  prettyprint-Disambiguator :
+    amb([h|hs]) -> <prettyprint-Disambiguator> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Constraints
+
+  prettyprint-example =
+    prettyprint-Filters
+
+  prettyprint-example =
+    prettyprint-Proposition
+
+  prettyprint-Constraints :
+    NoWhere() -> [ H(
+                     []
+                   , [S("")]
+                   )
+                 ]
+
+  is-Constraints =
+    ?NoWhere()
+
+  prettyprint-Constraints :
+    Where(t1__) -> [ H(
+                       [SOpt(HS(), "0")]
+                     , [S("where "), t1__']
+                     )
+                   ]
+    with t1__' := <pp-one-Z(prettyprint-Formula)> t1__
+
+  is-Constraints =
+    ?Where(_)
+
+  prettyprint-Filters :
+    Filter(t1__) -> [ H(
+                        [SOpt(HS(), "0")]
+                      , [S("with "), t1__']
+                      )
+                    ]
+    with t1__' := <pp-one-Z(prettyprint-Formula)> t1__
+
+  is-Filters =
+    ?Filter(_)
+
+  prettyprint-Proposition :
+    PropertyPattern(t1__, t2__, t3__) -> [ H(
+                                             [SOpt(HS(), "0")]
+                                           , [ t1__'
+                                             , S(" has ")
+                                             , t2__'
+                                             , S(" ")
+                                             , t3__'
+                                             ]
+                                           )
+                                         ]
+    with t1__' := <pp-one-Z(prettyprint-VarRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-PropertyRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Pattern)> t3__
+
+  is-Proposition =
+    ?PropertyPattern(_, _, _)
+
+  is-Constraints =
+    fail
+
+  is-Filters =
+    fail
+
+  is-Proposition =
+    fail
+
+  prettyprint-Constraints :
+    amb([h|hs]) -> <prettyprint-Constraints> h
+
+  prettyprint-Filters :
+    amb([h|hs]) -> <prettyprint-Filters> h
+
+  prettyprint-Proposition :
+    amb([h|hs]) -> <prettyprint-Proposition> h

--- a/Xtext/nabl/src-gen/pp/common/Identifiers-pp.str
+++ b/Xtext/nabl/src-gen/pp/common/Identifiers-pp.str
@@ -1,0 +1,56 @@
+module nabl/src-gen/pp/common/Identifiers-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/common/Identifiers-sig
+
+
+strategies
+  prettyprint-LId =
+    ![S(<is-string>)]
+
+  prettyprint-Id =
+    ![S(<is-string>)]
+
+  prettyprint-LCID =
+    ![S(<is-string>)]
+
+  prettyprint-UCID =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-LId
+
+  prettyprint-example =
+    prettyprint-Id
+
+  prettyprint-example =
+    prettyprint-LCID
+
+  prettyprint-example =
+    prettyprint-UCID
+
+  prettyprint-LId :
+    amb([h|hs]) -> <prettyprint-LId> h
+
+  prettyprint-Id :
+    amb([h|hs]) -> <prettyprint-Id> h
+
+  prettyprint-LCID :
+    amb([h|hs]) -> <prettyprint-LCID> h
+
+  prettyprint-UCID :
+    amb([h|hs]) -> <prettyprint-UCID> h
+
+
+strategies
+  prettyprint-Keyword =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-Keyword
+
+  prettyprint-Keyword :
+    amb([h|hs]) -> <prettyprint-Keyword> h

--- a/Xtext/nabl/src-gen/pp/common/Layout-pp.str
+++ b/Xtext/nabl/src-gen/pp/common/Layout-pp.str
@@ -1,0 +1,45 @@
+module nabl/src-gen/pp/common/Layout-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/common/Layout-sig
+
+
+strategies
+  prettyprint-Eof =
+    ![S(<is-string>)]
+
+  prettyprint-LongCom =
+    ![S(<is-string>)]
+
+  prettyprint-CommChar =
+    ![S(<is-string>)]
+
+  prettyprint-Asterisk =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-Eof
+
+  prettyprint-example =
+    prettyprint-LongCom
+
+  prettyprint-example =
+    prettyprint-CommChar
+
+  prettyprint-example =
+    prettyprint-Asterisk
+
+  prettyprint-Eof :
+    amb([h|hs]) -> <prettyprint-Eof> h
+
+  prettyprint-LongCom :
+    amb([h|hs]) -> <prettyprint-LongCom> h
+
+  prettyprint-CommChar :
+    amb([h|hs]) -> <prettyprint-CommChar> h
+
+  prettyprint-Asterisk :
+    amb([h|hs]) -> <prettyprint-Asterisk> h

--- a/Xtext/nabl/src-gen/pp/core/Modules-pp.str
+++ b/Xtext/nabl/src-gen/pp/core/Modules-pp.str
@@ -1,0 +1,115 @@
+module nabl/src-gen/pp/core/Modules-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Modules-sig
+
+
+strategies
+  prettyprint-example =
+    prettyprint-nabl-Module
+
+  prettyprint-example =
+    prettyprint-nabl-ModuleSection
+
+  prettyprint-example =
+    prettyprint-ImportModule
+
+  prettyprint-nabl-Module :
+    Module(t1__, t2__) -> [ H(
+                              [SOpt(HS(), "0")]
+                            , [S("module "), t1__']
+                            )
+                          , H(
+                              []
+                            , [S("")]
+                            )
+                          , t2__'
+                          ]
+    with t1__' := <pp-one-Z(prettyprint-nabl-ModuleID)> t1__
+    with t2__' := <pp-indent(|"4")> [<pp-H-list(prettyprint-nabl-ModuleSection)> t2__]
+
+  is-Module =
+    ?Module(_, _)
+
+  prettyprint-nabl-ModuleSection :
+    Imports(t1__) -> [ H(
+                         [SOpt(HS(), "0")]
+                       , [S("imports "), t1__']
+                       )
+                     ]
+    with t1__' := <pp-H-list(prettyprint-ImportModule)> t1__
+
+  is-ModuleSection =
+    ?Imports(_)
+
+  prettyprint-ImportModule :
+    ImportWildcard(t1__) -> [ H(
+                                [SOpt(HS(), "0")]
+                              , [t1__', S("/-")]
+                              )
+                            ]
+    with t1__' := <pp-one-Z(prettyprint-nabl-ModuleID)> t1__
+
+  is-ImportModule =
+    ?ImportWildcard(_)
+
+  prettyprint-ImportModule :
+    Import(t1__) -> [ H(
+                        [SOpt(HS(), "0")]
+                      , [t1__']
+                      )
+                    ]
+    with t1__' := <pp-one-Z(prettyprint-nabl-ModuleID)> t1__
+
+  is-ImportModule =
+    ?Import(_)
+
+  is-Module =
+    fail
+
+  is-ModuleSection =
+    fail
+
+  is-ImportModule =
+    fail
+
+  prettyprint-nabl-Module :
+    amb([h|hs]) -> <prettyprint-nabl-Module> h
+
+  prettyprint-nabl-ModuleSection :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleSection> h
+
+  prettyprint-ImportModule :
+    amb([h|hs]) -> <prettyprint-ImportModule> h
+
+
+strategies
+  prettyprint-nabl-ModuleID =
+    ![S(<is-string>)]
+
+  prettyprint-nabl-ModuleIDPart =
+    ![S(<is-string>)]
+
+  prettyprint-SectionKeyword =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-nabl-ModuleID
+
+  prettyprint-example =
+    prettyprint-nabl-ModuleIDPart
+
+  prettyprint-example =
+    prettyprint-SectionKeyword
+
+  prettyprint-nabl-ModuleID :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleID> h
+
+  prettyprint-nabl-ModuleIDPart :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleIDPart> h
+
+  prettyprint-SectionKeyword :
+    amb([h|hs]) -> <prettyprint-SectionKeyword> h

--- a/Xtext/nabl/src-gen/pp/core/Namespaces-pp.str
+++ b/Xtext/nabl/src-gen/pp/core/Namespaces-pp.str
@@ -1,0 +1,131 @@
+module nabl/src-gen/pp/core/Namespaces-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Namespaces-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/core/Modules-sig
+
+
+imports
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/core/Modules-pp
+
+
+strategies
+  prettyprint-NamespaceID =
+    ![S(<is-string>)]
+
+  prettyprint-SectionKeyword =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-NamespaceID
+
+  prettyprint-example =
+    prettyprint-SectionKeyword
+
+  prettyprint-NamespaceID :
+    amb([h|hs]) -> <prettyprint-NamespaceID> h
+
+  prettyprint-SectionKeyword :
+    amb([h|hs]) -> <prettyprint-SectionKeyword> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-nabl-ModuleSection
+
+  prettyprint-example =
+    prettyprint-NamespaceDef
+
+  prettyprint-example =
+    prettyprint-NamespaceRef
+
+  prettyprint-example =
+    prettyprint-LanguageRef
+
+  prettyprint-nabl-ModuleSection :
+    Namespaces(t1__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [S("namespaces")]
+                          )
+                        , t1__'
+                        ]
+    with t1__' := <pp-indent(|"2")> [<pp-H-list(prettyprint-NamespaceDef)> t1__]
+
+  is-ModuleSection =
+    ?Namespaces(_)
+
+  prettyprint-NamespaceDef :
+    NamespaceDef(t1__) -> [ H(
+                              [SOpt(HS(), "0")]
+                            , [t1__']
+                            )
+                          ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceID)> t1__
+
+  is-NamespaceDef =
+    ?NamespaceDef(_)
+
+  prettyprint-NamespaceRef :
+    NamespaceRef(t1__, t2__) -> [ H(
+                                    [SOpt(HS(), "0")]
+                                  , [t1__', t2__']
+                                  )
+                                ]
+    with t1__' := <pp-one-Z(prettyprint-LanguageRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceID)> t2__
+
+  is-NamespaceRef =
+    ?NamespaceRef(_, _)
+
+  prettyprint-LanguageRef :
+    CurrentLanguage() -> [ H(
+                             []
+                           , [S("")]
+                           )
+                         ]
+
+  is-LanguageRef =
+    ?CurrentLanguage()
+
+  prettyprint-LanguageRef :
+    LanguageRef(t1__) -> [ H(
+                             [SOpt(HS(), "0")]
+                           , [t1__', S(".")]
+                           )
+                         ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+
+  is-LanguageRef =
+    ?LanguageRef(_)
+
+  is-ModuleSection =
+    fail
+
+  is-NamespaceDef =
+    fail
+
+  is-NamespaceRef =
+    fail
+
+  is-LanguageRef =
+    fail
+
+  prettyprint-nabl-ModuleSection :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleSection> h
+
+  prettyprint-NamespaceDef :
+    amb([h|hs]) -> <prettyprint-NamespaceDef> h
+
+  prettyprint-NamespaceRef :
+    amb([h|hs]) -> <prettyprint-NamespaceRef> h
+
+  prettyprint-LanguageRef :
+    amb([h|hs]) -> <prettyprint-LanguageRef> h

--- a/Xtext/nabl/src-gen/pp/core/Properties-pp.str
+++ b/Xtext/nabl/src-gen/pp/core/Properties-pp.str
@@ -1,0 +1,134 @@
+module nabl/src-gen/pp/core/Properties-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Properties-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Signatures-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Formulas-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+
+
+imports
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/terms/Signatures-pp
+  nabl/src-gen/pp/terms/Vars-pp
+  nabl/src-gen/pp/terms/Terms-pp
+  nabl/src-gen/pp/formulas/Formulas-pp
+  nabl/src-gen/pp/core/Namespaces-pp
+
+
+strategies
+  prettyprint-PropertyID =
+    ![S(<is-string>)]
+
+  prettyprint-SectionKeyword =
+    ![S(<is-string>)]
+
+  prettyprint-Relation =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-PropertyID
+
+  prettyprint-example =
+    prettyprint-SectionKeyword
+
+  prettyprint-example =
+    prettyprint-Relation
+
+  prettyprint-PropertyID :
+    amb([h|hs]) -> <prettyprint-PropertyID> h
+
+  prettyprint-SectionKeyword :
+    amb([h|hs]) -> <prettyprint-SectionKeyword> h
+
+  prettyprint-Relation :
+    amb([h|hs]) -> <prettyprint-Relation> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-nabl-ModuleSection
+
+  prettyprint-example =
+    prettyprint-PropertyDef
+
+  prettyprint-example =
+    prettyprint-PropertyRef
+
+  prettyprint-nabl-ModuleSection :
+    Properties(t1__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [S("properties")]
+                          )
+                        , t1__'
+                        ]
+    with t1__' := <pp-indent(|"2")> [<pp-H-list(prettyprint-PropertyDef)> t1__]
+
+  is-ModuleSection =
+    ?Properties(_)
+
+  prettyprint-PropertyDef :
+    PropertyDef(t1__, t2__, t3__) -> [ H(
+                                         [SOpt(HS(), "0")]
+                                       , [ t1__'
+                                         , S(" of ")
+                                         , t2__'
+                                         , S(" : ")
+                                         , t3__'
+                                         ]
+                                       )
+                                     ]
+    with t1__' := <pp-one-Z(prettyprint-PropertyID)> t1__
+    with t2__' := <pp-H-list(prettyprint-NamespaceRef|", ")> t2__
+    with t3__' := <pp-one-Z(prettyprint-Sort)> t3__
+
+  is-PropertyDef =
+    ?PropertyDef(_, _, _)
+
+  prettyprint-PropertyRef :
+    TypeProp() -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [S("type")]
+                    )
+                  ]
+
+  is-PropertyRef =
+    ?TypeProp()
+
+  prettyprint-PropertyRef :
+    PropertyRef(t1__) -> [ H(
+                             [SOpt(HS(), "0")]
+                           , [t1__']
+                           )
+                         ]
+    with t1__' := <pp-one-Z(prettyprint-PropertyID)> t1__
+
+  is-PropertyRef =
+    ?PropertyRef(_)
+
+  is-ModuleSection =
+    fail
+
+  is-PropertyDef =
+    fail
+
+  is-PropertyRef =
+    fail
+
+  prettyprint-nabl-ModuleSection :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleSection> h
+
+  prettyprint-PropertyDef :
+    amb([h|hs]) -> <prettyprint-PropertyDef> h
+
+  prettyprint-PropertyRef :
+    amb([h|hs]) -> <prettyprint-PropertyRef> h

--- a/Xtext/nabl/src-gen/pp/core/Scopes-pp.str
+++ b/Xtext/nabl/src-gen/pp/core/Scopes-pp.str
@@ -1,0 +1,193 @@
+module nabl/src-gen/pp/core/Scopes-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/core/Scopes-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/core/Namespaces-pp
+  nabl/src-gen/pp/terms/Vars-pp
+
+
+strategies
+  prettyprint-ScopeID =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-ScopeID
+
+  prettyprint-ScopeID :
+    amb([h|hs]) -> <prettyprint-ScopeID> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-LocalScope
+
+  prettyprint-example =
+    prettyprint-Scope
+
+  prettyprint-LocalScope :
+    NamedScope(t1__, t2__) -> [ H(
+                                  [SOpt(HS(), "0")]
+                                , [t1__', S(" "), t2__']
+                                )
+                              ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-VarRef)> t2__
+
+  is-LocalScope =
+    ?NamedScope(_, _)
+
+  prettyprint-LocalScope :
+    CurrentScope(t1__) -> [ H(
+                              [SOpt(HS(), "0")]
+                            , [ S("current ")
+                              , t1__'
+                              , S(" scope")
+                              ]
+                            )
+                          ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+
+  is-LocalScope =
+    ?CurrentScope(_)
+
+  prettyprint-LocalScope :
+    TermScope(t1__, t2__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [t1__', S(" scope  at "), t2__']
+                               )
+                             ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-VarRef)> t2__
+
+  is-LocalScope =
+    ?TermScope(_, _)
+
+  prettyprint-LocalScope :
+    Enclosing(t1__, t2__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [ S("enclosing ")
+                                 , t1__'
+                                 , S(" of ")
+                                 , t2__'
+                                 ]
+                               )
+                             ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-LocalScope)> t2__
+
+  is-LocalScope =
+    ?Enclosing(_, _)
+
+  prettyprint-Scope :
+    GlobalScope() -> [ H(
+                         [SOpt(HS(), "0")]
+                       , [S("global scope")]
+                       )
+                     ]
+
+  is-Scope =
+    ?GlobalScope()
+
+  prettyprint-Scope :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Scope)
+    where t1__' := <pp-one-Z(prettyprint-LocalScope)> t1__
+
+  prettyprint-Scope :
+    Anonymous(t1__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [S("new scope in "), t1__']
+                         )
+                       ]
+    with t1__' := <pp-one-Z(prettyprint-Scope)> t1__
+
+  is-Scope =
+    ?Anonymous(_)
+
+  is-LocalScope =
+    fail
+
+  is-Scope =
+    fail
+
+  prettyprint-LocalScope :
+    amb([h|hs]) -> <prettyprint-LocalScope> h
+
+  prettyprint-Scope :
+    amb([h|hs]) -> <prettyprint-Scope> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Clause
+
+  prettyprint-Clause :
+    ChildScope(t1__, t2__) -> [ H(
+                                  [SOpt(HS(), "0")]
+                                , [ t1__'
+                                  , S(" scopes ")
+                                  , t2__'
+                                  , S(" at child nodes")
+                                  ]
+                                )
+                              ]
+    with t1__' := <pp-one-Z(prettyprint-Scope)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+
+  is-Clause =
+    ?ChildScope(_, _)
+
+  prettyprint-Clause :
+    SubsequentScope(t1__, t2__) -> [ H(
+                                       [SOpt(HS(), "0")]
+                                     , [ t1__'
+                                       , S(" scopes ")
+                                       , t2__'
+                                       , S(" at subsequent nodes")
+                                       ]
+                                     )
+                                   ]
+    with t1__' := <pp-one-Z(prettyprint-Scope)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+
+  is-Clause =
+    ?SubsequentScope(_, _)
+
+  prettyprint-Clause :
+    NodeScope(t1__, t2__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [ S("requires ")
+                                 , t1__'
+                                 , S(" scope at ")
+                                 , t2__'
+                                 ]
+                               )
+                             ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-VarRef)> t2__
+
+  is-Clause =
+    ?NodeScope(_, _)
+
+  is-Clause =
+    fail
+
+  prettyprint-Clause :
+    amb([h|hs]) -> <prettyprint-Clause> h

--- a/Xtext/nabl/src-gen/pp/formulas/Formulas-pp.str
+++ b/Xtext/nabl/src-gen/pp/formulas/Formulas-pp.str
@@ -1,0 +1,91 @@
+module nabl/src-gen/pp/formulas/Formulas-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/formulas/Formulas-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Propositions-sig
+
+
+imports
+  nabl/src-gen/pp/terms/Terms-pp
+  nabl/src-gen/pp/formulas/Propositions-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Formula
+
+  prettyprint-Formula :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Formula)
+    where t1__' := <pp-one-Z(prettyprint-Proposition)> t1__
+
+  prettyprint-Formula :
+    Not(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [S("not "), t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-Formula)> t1__
+
+  is-Formula =
+    ?Not(_)
+
+  prettyprint-Formula :
+    And(t1__, t2__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [t1__']
+                         )
+                       , H(
+                           [SOpt(HS(), "0")]
+                         , [S("and "), t2__']
+                         )
+                       ]
+    with t1__' := <pp-one-Z(prettyprint-Formula)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Formula)> t2__
+
+  is-Formula =
+    ?And(_, _)
+
+  prettyprint-Formula :
+    Or(t1__, t2__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [t1__']
+                        )
+                      , H(
+                          [SOpt(HS(), "0")]
+                        , [S("or "), t2__']
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-Formula)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Formula)> t2__
+
+  is-Formula =
+    ?Or(_, _)
+
+  prettyprint-Formula :
+    Parenthetical(t1__) -> [ H(
+                               [SOpt(HS(), "0")]
+                             , [ S("(")
+                               , t1__'
+                               , S(")")
+                               ]
+                             )
+                           ]
+    with t1__' := <pp-one-Z(prettyprint-Formula)> t1__
+
+  is-Formula =
+    fail
+
+  prettyprint-Formula :
+    amb([h|hs]) -> <prettyprint-Formula> h

--- a/Xtext/nabl/src-gen/pp/formulas/Messages-pp.str
+++ b/Xtext/nabl/src-gen/pp/formulas/Messages-pp.str
@@ -1,0 +1,83 @@
+module nabl/src-gen/pp/formulas/Messages-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/formulas/Messages-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/pp/terms/Terms-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Message
+
+  prettyprint-example =
+    prettyprint-MessageKind
+
+  prettyprint-Message :
+    Message(t1__, t2__, t3__) -> [ H(
+                                     [SOpt(HS(), "0")]
+                                   , [ t1__'
+                                     , S(" ")
+                                     , t2__'
+                                     , S(" on ")
+                                     , t3__'
+                                     ]
+                                   )
+                                 ]
+    with t1__' := <pp-one-Z(prettyprint-MessageKind)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Term)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+
+  is-Message =
+    ?Message(_, _, _)
+
+  prettyprint-MessageKind :
+    Error() -> [ H(
+                   [SOpt(HS(), "0")]
+                 , [S("error")]
+                 )
+               ]
+
+  is-MessageKind =
+    ?Error()
+
+  prettyprint-MessageKind :
+    Warning() -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [S("warning")]
+                   )
+                 ]
+
+  is-MessageKind =
+    ?Warning()
+
+  prettyprint-MessageKind :
+    Note() -> [ H(
+                  [SOpt(HS(), "0")]
+                , [S("note")]
+                )
+              ]
+
+  is-MessageKind =
+    ?Note()
+
+  is-Message =
+    fail
+
+  is-MessageKind =
+    fail
+
+  prettyprint-Message :
+    amb([h|hs]) -> <prettyprint-Message> h
+
+  prettyprint-MessageKind :
+    amb([h|hs]) -> <prettyprint-MessageKind> h

--- a/Xtext/nabl/src-gen/pp/formulas/Propositions-pp.str
+++ b/Xtext/nabl/src-gen/pp/formulas/Propositions-pp.str
@@ -1,0 +1,179 @@
+module nabl/src-gen/pp/formulas/Propositions-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/formulas/Propositions-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/core/Scopes-sig
+  nabl/src-gen/signatures/core/Properties-sig
+
+
+imports
+  nabl/src-gen/pp/terms/Terms-pp
+  nabl/src-gen/pp/terms/Vars-pp
+  nabl/src-gen/pp/core/Namespaces-pp
+  nabl/src-gen/pp/core/Scopes-pp
+  nabl/src-gen/pp/core/Properties-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Proposition
+
+  prettyprint-Proposition :
+    True() -> [ H(
+                  [SOpt(HS(), "0")]
+                , [S("true")]
+                )
+              ]
+
+  is-Proposition =
+    ?True()
+
+  prettyprint-Proposition :
+    False() -> [ H(
+                   [SOpt(HS(), "0")]
+                 , [S("false")]
+                 )
+               ]
+
+  is-Proposition =
+    ?False()
+
+  prettyprint-Proposition :
+    Eq(t1__, t2__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [t1__', S(" == "), t2__']
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-VarRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Term)> t2__
+
+  is-Proposition =
+    ?Eq(_, _)
+
+  prettyprint-Proposition :
+    Match(t1__, t2__) -> [ H(
+                             [SOpt(HS(), "0")]
+                           , [t1__', S(" => "), t2__']
+                           )
+                         ]
+    with t1__' := <pp-one-Z(prettyprint-VarRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Pattern)> t2__
+
+  is-Proposition =
+    ?Match(_, _)
+
+  prettyprint-Proposition :
+    DefOf(t1__, t2__) -> [ H(
+                             [SOpt(HS(), "0")]
+                           , [ S("definition of ")
+                             , t1__'
+                             , S(" => ")
+                             , t2__'
+                             ]
+                           )
+                         ]
+    with t1__' := <pp-one-Z(prettyprint-VarRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Var)> t2__
+
+  is-Proposition =
+    ?DefOf(_, _)
+
+  prettyprint-Proposition :
+    DefOf(t1__, t2__, t3__) -> [ H(
+                                   [SOpt(HS(), "0")]
+                                 , [ S("definition of ")
+                                   , t1__'
+                                   , S(" ")
+                                   , t2__'
+                                   , S(" => ")
+                                   , t3__'
+                                   ]
+                                 )
+                               ]
+    with t1__' := <pp-one-Z(prettyprint-NamespaceRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-VarRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Var)> t3__
+
+  is-Proposition =
+    ?DefOf(_, _, _)
+
+  prettyprint-Proposition :
+    ScopeOf(t1__, t2__) -> [ H(
+                               [SOpt(HS(), "0")]
+                             , [t1__', S(" => "), t2__']
+                             )
+                           ]
+    with t1__' := <pp-one-Z(prettyprint-Scope)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Var)> t2__
+
+  is-Proposition =
+    ?ScopeOf(_, _)
+
+  prettyprint-Proposition :
+    ResolvesTo(t1__, t2__, t3__) -> [ H(
+                                        [SOpt(HS(), "0")]
+                                      , [ t1__'
+                                        , S(" resolves to ")
+                                        , t2__'
+                                        , S(" ")
+                                        , t3__'
+                                        ]
+                                      )
+                                    ]
+    with t1__' := <pp-one-Z(prettyprint-Term)> t1__
+    with t2__' := <pp-one-Z(prettyprint-NamespaceRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Var)> t3__
+
+  is-Proposition =
+    ?ResolvesTo(_, _, _)
+
+  prettyprint-Proposition :
+    HasProperty(t1__, t2__, t3__) -> [ H(
+                                         [SOpt(HS(), "0")]
+                                       , [ t1__'
+                                         , S(" has ")
+                                         , t2__'
+                                         , S(" ")
+                                         , t3__'
+                                         ]
+                                       )
+                                     ]
+    with t1__' := <pp-one-Z(prettyprint-VarRef)> t1__
+    with t2__' := <pp-one-Z(prettyprint-PropertyRef)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Var)> t3__
+
+  is-Proposition =
+    ?HasProperty(_, _, _)
+
+  prettyprint-Proposition :
+    InRelation(t1__, t2__, t3__) -> [ H(
+                                        [SOpt(HS(), "0")]
+                                      , [ t1__'
+                                        , S(" ")
+                                        , t2__'
+                                        , S(" ")
+                                        , t3__'
+                                        ]
+                                      )
+                                    ]
+    with t1__' := <pp-one-Z(prettyprint-Term)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Relation)> t2__
+    with t3__' := <pp-one-Z(prettyprint-Term)> t3__
+
+  is-Proposition =
+    ?InRelation(_, _, _)
+
+  is-Proposition =
+    fail
+
+  prettyprint-Proposition :
+    amb([h|hs]) -> <prettyprint-Proposition> h

--- a/Xtext/nabl/src-gen/pp/lexical/Identifiers-pp.str
+++ b/Xtext/nabl/src-gen/pp/lexical/Identifiers-pp.str
@@ -1,0 +1,63 @@
+module nabl/src-gen/pp/lexical/Identifiers-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/lexical/Identifiers-sig
+
+
+strategies
+  prettyprint-Id =
+    ![S(<is-string>)]
+
+  prettyprint-LId =
+    ![S(<is-string>)]
+
+  prettyprint-LCID =
+    ![S(<is-string>)]
+
+  prettyprint-UCID =
+    ![S(<is-string>)]
+
+  prettyprint-nabl-ModuleID =
+    ![S(<is-string>)]
+
+  prettyprint-nabl-ModuleIDPart =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-Id
+
+  prettyprint-example =
+    prettyprint-LId
+
+  prettyprint-example =
+    prettyprint-LCID
+
+  prettyprint-example =
+    prettyprint-UCID
+
+  prettyprint-example =
+    prettyprint-nabl-ModuleID
+
+  prettyprint-example =
+    prettyprint-nabl-ModuleIDPart
+
+  prettyprint-Id :
+    amb([h|hs]) -> <prettyprint-Id> h
+
+  prettyprint-LId :
+    amb([h|hs]) -> <prettyprint-LId> h
+
+  prettyprint-LCID :
+    amb([h|hs]) -> <prettyprint-LCID> h
+
+  prettyprint-UCID :
+    amb([h|hs]) -> <prettyprint-UCID> h
+
+  prettyprint-nabl-ModuleID :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleID> h
+
+  prettyprint-nabl-ModuleIDPart :
+    amb([h|hs]) -> <prettyprint-nabl-ModuleIDPart> h

--- a/Xtext/nabl/src-gen/pp/lexical/Layout-pp.str
+++ b/Xtext/nabl/src-gen/pp/lexical/Layout-pp.str
@@ -1,0 +1,45 @@
+module nabl/src-gen/pp/lexical/Layout-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/lexical/Layout-sig
+
+
+strategies
+  prettyprint-Eof =
+    ![S(<is-string>)]
+
+  prettyprint-LongCom =
+    ![S(<is-string>)]
+
+  prettyprint-CommChar =
+    ![S(<is-string>)]
+
+  prettyprint-Asterisk =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-Eof
+
+  prettyprint-example =
+    prettyprint-LongCom
+
+  prettyprint-example =
+    prettyprint-CommChar
+
+  prettyprint-example =
+    prettyprint-Asterisk
+
+  prettyprint-Eof :
+    amb([h|hs]) -> <prettyprint-Eof> h
+
+  prettyprint-LongCom :
+    amb([h|hs]) -> <prettyprint-LongCom> h
+
+  prettyprint-CommChar :
+    amb([h|hs]) -> <prettyprint-CommChar> h
+
+  prettyprint-Asterisk :
+    amb([h|hs]) -> <prettyprint-Asterisk> h

--- a/Xtext/nabl/src-gen/pp/terms/Constants-pp.str
+++ b/Xtext/nabl/src-gen/pp/terms/Constants-pp.str
@@ -1,0 +1,65 @@
+module nabl/src-gen/pp/terms/Constants-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Constants-sig
+
+
+strategies
+  prettyprint-Int =
+    ![S(<is-string>)]
+
+  prettyprint-Real =
+    ![S(<is-string>)]
+
+  prettyprint-String =
+    ![S(<is-string>)]
+
+  prettyprint-StrChar =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-Int
+
+  prettyprint-example =
+    prettyprint-Real
+
+  prettyprint-example =
+    prettyprint-String
+
+  prettyprint-example =
+    prettyprint-StrChar
+
+  prettyprint-Int :
+    amb([h|hs]) -> <prettyprint-Int> h
+
+  prettyprint-Real :
+    amb([h|hs]) -> <prettyprint-Real> h
+
+  prettyprint-String :
+    amb([h|hs]) -> <prettyprint-String> h
+
+  prettyprint-StrChar :
+    amb([h|hs]) -> <prettyprint-StrChar> h
+
+
+strategies
+  prettyprint-Char =
+    ![S(<is-string>)]
+
+  prettyprint-CharChar =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-Char
+
+  prettyprint-example =
+    prettyprint-CharChar
+
+  prettyprint-Char :
+    amb([h|hs]) -> <prettyprint-Char> h
+
+  prettyprint-CharChar :
+    amb([h|hs]) -> <prettyprint-CharChar> h

--- a/Xtext/nabl/src-gen/pp/terms/Signatures-pp.str
+++ b/Xtext/nabl/src-gen/pp/terms/Signatures-pp.str
@@ -1,0 +1,189 @@
+module nabl/src-gen/pp/terms/Signatures-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Signatures-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Constants-sig
+
+
+imports
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/terms/Constants-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Sort
+
+  prettyprint-Sort :
+    SortVar(t1__) -> [ H(
+                         [SOpt(HS(), "0")]
+                       , [t1__']
+                       )
+                     ]
+    with t1__' := <pp-one-Z(prettyprint-LCID)> t1__
+
+  is-Sort =
+    ?SortVar(_)
+
+  prettyprint-Sort :
+    SortNoArgs(t1__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [t1__']
+                          )
+                        ]
+    with t1__' := <pp-one-Z(prettyprint-UCID)> t1__
+
+  is-Sort =
+    ?SortNoArgs(_)
+
+  prettyprint-Sort :
+    Sort(t1__, t2__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [ t1__'
+                            , S(" ( ")
+                            , t2__'
+                            , S(" )")
+                            ]
+                          )
+                        ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+    with t2__' := <pp-H-list(prettyprint-Sort|",")> t2__
+
+  is-Sort =
+    ?Sort(_, _)
+
+  is-Sort =
+    fail
+
+  prettyprint-Sort :
+    amb([h|hs]) -> <prettyprint-Sort> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-TypeDecl
+
+  prettyprint-example =
+    prettyprint-PPTerm
+
+  prettyprint-TypeDecl :
+    TypeDecl(t1__, t2__, t3__) -> [ H(
+                                      [SOpt(HS(), "0")]
+                                    , [ t1__'
+                                      , S(" ")
+                                      , t2__'
+                                      , S(" ")
+                                      , t3__'
+                                      ]
+                                    )
+                                  ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+    with t2__' := <pp-one-Z(prettyprint-TypeParams)> t2__
+    with t3__' := <pp-one-Z(prettyprint-PPTerm)> t3__
+
+  is-TypeDecl =
+    ?TypeDecl(_, _, _)
+
+  prettyprint-TypeDecl :
+    TypeDeclQ(t1__, t2__, t3__) -> [ H(
+                                       [SOpt(HS(), "0")]
+                                     , [ t1__'
+                                       , S(" ")
+                                       , t2__'
+                                       , S(" ")
+                                       , t3__'
+                                       ]
+                                     )
+                                   ]
+    with t1__' := <pp-one-Z(prettyprint-String)> t1__
+    with t2__' := <pp-one-Z(prettyprint-TypeParams)> t2__
+    with t3__' := <pp-one-Z(prettyprint-PPTerm)> t3__
+
+  is-TypeDecl =
+    ?TypeDeclQ(_, _, _)
+
+  prettyprint-PPTerm :
+    Str(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-String)> t1__
+
+  is-PPTerm =
+    ?Str(_)
+
+  is-TypeDecl =
+    fail
+
+  is-PPTerm =
+    fail
+
+  prettyprint-TypeDecl :
+    amb([h|hs]) -> <prettyprint-TypeDecl> h
+
+  prettyprint-PPTerm :
+    amb([h|hs]) -> <prettyprint-PPTerm> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-TypeParams
+
+  prettyprint-example =
+    prettyprint-TypeParam
+
+  prettyprint-TypeParams :
+    NoTypeParams() -> [ H(
+                          []
+                        , [S("")]
+                        )
+                      ]
+
+  is-TypeParams =
+    ?NoTypeParams()
+
+  prettyprint-TypeParams :
+    TypeParams(t1__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [ S("( ")
+                            , t1__'
+                            , S(" )")
+                            ]
+                          )
+                        ]
+    with t1__' := <pp-H-list(prettyprint-TypeParam|",")> t1__
+
+  is-TypeParams =
+    ?TypeParams(_)
+
+  prettyprint-TypeParam :
+    TypeParam(t1__, t2__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [t1__', S(" : "), t2__']
+                               )
+                             ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Sort)> t2__
+
+  is-TypeParam =
+    ?TypeParam(_, _)
+
+  is-TypeParams =
+    fail
+
+  is-TypeParam =
+    fail
+
+  prettyprint-TypeParams :
+    amb([h|hs]) -> <prettyprint-TypeParams> h
+
+  prettyprint-TypeParam :
+    amb([h|hs]) -> <prettyprint-TypeParam> h

--- a/Xtext/nabl/src-gen/pp/terms/StringQuotations-pp.str
+++ b/Xtext/nabl/src-gen/pp/terms/StringQuotations-pp.str
@@ -1,0 +1,152 @@
+module nabl/src-gen/pp/terms/StringQuotations-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/StringQuotations-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/pp/terms/Terms-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-PPTerm
+
+  prettyprint-PPTerm :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-PPTerm)
+    where t1__' := <pp-one-Z(prettyprint-StringQuotation)> t1__
+
+  is-PPTerm =
+    fail
+
+  prettyprint-StringQuotedChars1 =
+    ![S(<is-string>)]
+
+  prettyprint-QuotedBracket1 =
+    ![S(<is-string>)]
+
+  prettyprint-Dollar1 =
+    ![S(<is-string>)]
+
+  prettyprint-StringQuotedChars2 =
+    ![S(<is-string>)]
+
+  prettyprint-QuotedBracket2 =
+    ![S(<is-string>)]
+
+  prettyprint-Dollar2 =
+    ![S(<is-string>)]
+
+  prettyprint-StringQuotedChars3 =
+    ![S(<is-string>)]
+
+  prettyprint-QuotedBracket3 =
+    ![S(<is-string>)]
+
+  prettyprint-Dollar3 =
+    ![S(<is-string>)]
+
+  prettyprint-StringQuotedChars4 =
+    ![S(<is-string>)]
+
+  prettyprint-QuotedBracket4 =
+    ![S(<is-string>)]
+
+  prettyprint-Dollar4 =
+    ![S(<is-string>)]
+
+  prettyprint-Padding =
+    ![S(<is-string>)]
+
+  prettyprint-example =
+    prettyprint-StringQuotedChars1
+
+  prettyprint-example =
+    prettyprint-QuotedBracket1
+
+  prettyprint-example =
+    prettyprint-Dollar1
+
+  prettyprint-example =
+    prettyprint-StringQuotedChars2
+
+  prettyprint-example =
+    prettyprint-QuotedBracket2
+
+  prettyprint-example =
+    prettyprint-Dollar2
+
+  prettyprint-example =
+    prettyprint-StringQuotedChars3
+
+  prettyprint-example =
+    prettyprint-QuotedBracket3
+
+  prettyprint-example =
+    prettyprint-Dollar3
+
+  prettyprint-example =
+    prettyprint-StringQuotedChars4
+
+  prettyprint-example =
+    prettyprint-QuotedBracket4
+
+  prettyprint-example =
+    prettyprint-Dollar4
+
+  prettyprint-example =
+    prettyprint-Padding
+
+  prettyprint-PPTerm :
+    amb([h|hs]) -> <prettyprint-PPTerm> h
+
+  prettyprint-StringQuotedChars1 :
+    amb([h|hs]) -> <prettyprint-StringQuotedChars1> h
+
+  prettyprint-QuotedBracket1 :
+    amb([h|hs]) -> <prettyprint-QuotedBracket1> h
+
+  prettyprint-Dollar1 :
+    amb([h|hs]) -> <prettyprint-Dollar1> h
+
+  prettyprint-StringQuotedChars2 :
+    amb([h|hs]) -> <prettyprint-StringQuotedChars2> h
+
+  prettyprint-QuotedBracket2 :
+    amb([h|hs]) -> <prettyprint-QuotedBracket2> h
+
+  prettyprint-Dollar2 :
+    amb([h|hs]) -> <prettyprint-Dollar2> h
+
+  prettyprint-StringQuotedChars3 :
+    amb([h|hs]) -> <prettyprint-StringQuotedChars3> h
+
+  prettyprint-QuotedBracket3 :
+    amb([h|hs]) -> <prettyprint-QuotedBracket3> h
+
+  prettyprint-Dollar3 :
+    amb([h|hs]) -> <prettyprint-Dollar3> h
+
+  prettyprint-StringQuotedChars4 :
+    amb([h|hs]) -> <prettyprint-StringQuotedChars4> h
+
+  prettyprint-QuotedBracket4 :
+    amb([h|hs]) -> <prettyprint-QuotedBracket4> h
+
+  prettyprint-Dollar4 :
+    amb([h|hs]) -> <prettyprint-Dollar4> h
+
+  prettyprint-Padding :
+    amb([h|hs]) -> <prettyprint-Padding> h

--- a/Xtext/nabl/src-gen/pp/terms/Terms-pp.str
+++ b/Xtext/nabl/src-gen/pp/terms/Terms-pp.str
@@ -1,0 +1,313 @@
+module nabl/src-gen/pp/terms/Terms-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/signatures/terms/Constants-sig
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/pp/terms/Constants-pp
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/terms/Vars-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Pattern
+
+  prettyprint-Pattern :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Pattern)
+    where t1__' := <pp-one-Z(prettyprint-Var)> t1__
+
+  prettyprint-Pattern :
+    Int(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-Int)> t1__
+
+  is-Pattern =
+    ?Int(_)
+
+  prettyprint-Pattern :
+    Real(t1__) -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [t1__']
+                    )
+                  ]
+    with t1__' := <pp-one-Z(prettyprint-Real)> t1__
+
+  is-Pattern =
+    ?Real(_)
+
+  prettyprint-Pattern :
+    Str(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-String)> t1__
+
+  is-Pattern =
+    ?Str(_)
+
+  prettyprint-Pattern :
+    Op(t1__, t2__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [ t1__'
+                          , S("(")
+                          , t2__'
+                          , S(")")
+                          ]
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+    with t2__' := <pp-H-list(prettyprint-Pattern|", ")> t2__
+
+  is-Pattern =
+    ?Op(_, _)
+
+  prettyprint-Pattern :
+    OpQ(t1__, t2__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [ t1__'
+                           , S("(")
+                           , t2__'
+                           , S(")")
+                           ]
+                         )
+                       ]
+    with t1__' := <pp-one-Z(prettyprint-String)> t1__
+    with t2__' := <pp-H-list(prettyprint-Pattern|", ")> t2__
+
+  is-Pattern =
+    ?OpQ(_, _)
+
+  prettyprint-Pattern :
+    Char(t1__) -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [t1__']
+                    )
+                  ]
+    with t1__' := <pp-one-Z(prettyprint-Char)> t1__
+
+  is-Pattern =
+    ?Char(_)
+
+  prettyprint-Pattern :
+    Tuple(t1__) -> [ H(
+                       [SOpt(HS(), "0")]
+                     , [ S("(")
+                       , t1__'
+                       , S(")")
+                       ]
+                     )
+                   ]
+    with t1__' := <pp-H-list(prettyprint-Pattern|", ")> t1__
+
+  is-Pattern =
+    ?Tuple(_)
+
+  prettyprint-Pattern :
+    List(t1__) -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [ S("[")
+                      , t1__'
+                      , S("]")
+                      ]
+                    )
+                  ]
+    with t1__' := <pp-H-list(prettyprint-Pattern|", ")> t1__
+
+  is-Pattern =
+    ?List(_)
+
+  prettyprint-Pattern :
+    ListTail(t1__, t2__) -> [ H(
+                                [SOpt(HS(), "0")]
+                              , [ S("[")
+                                , t1__'
+                                , S(" | ")
+                                , t2__'
+                                , S("]")
+                                ]
+                              )
+                            ]
+    with t1__' := <pp-H-list(prettyprint-Pattern|", ")> t1__
+    with t2__' := <pp-one-Z(prettyprint-Pattern)> t2__
+
+  is-Pattern =
+    ?ListTail(_, _)
+
+  prettyprint-Pattern :
+    As(t1__, t2__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [t1__', S("@"), t2__']
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-Var)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Pattern)> t2__
+
+  is-Pattern =
+    ?As(_, _)
+
+  is-Pattern =
+    fail
+
+  prettyprint-Pattern :
+    amb([h|hs]) -> <prettyprint-Pattern> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Term
+
+  prettyprint-Term :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Term)
+    where t1__' := <pp-one-Z(prettyprint-VarRef)> t1__
+
+  prettyprint-Term :
+    Int(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-Int)> t1__
+
+  is-Term =
+    ?Int(_)
+
+  prettyprint-Term :
+    Real(t1__) -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [t1__']
+                    )
+                  ]
+    with t1__' := <pp-one-Z(prettyprint-Real)> t1__
+
+  is-Term =
+    ?Real(_)
+
+  prettyprint-Term :
+    Str(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-String)> t1__
+
+  is-Term =
+    ?Str(_)
+
+  prettyprint-Term :
+    Op(t1__, t2__) -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [ t1__'
+                          , S("(")
+                          , t2__'
+                          , S(")")
+                          ]
+                        )
+                      ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+    with t2__' := <pp-H-list(prettyprint-Term|", ")> t2__
+
+  is-Term =
+    ?Op(_, _)
+
+  prettyprint-Term :
+    OpQ(t1__, t2__) -> [ H(
+                           [SOpt(HS(), "0")]
+                         , [ t1__'
+                           , S("(")
+                           , t2__'
+                           , S(")")
+                           ]
+                         )
+                       ]
+    with t1__' := <pp-one-Z(prettyprint-String)> t1__
+    with t2__' := <pp-H-list(prettyprint-Term|", ")> t2__
+
+  is-Term =
+    ?OpQ(_, _)
+
+  prettyprint-Term :
+    Char(t1__) -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [t1__']
+                    )
+                  ]
+    with t1__' := <pp-one-Z(prettyprint-Char)> t1__
+
+  is-Term =
+    ?Char(_)
+
+  prettyprint-Term :
+    Tuple(t1__) -> [ H(
+                       [SOpt(HS(), "0")]
+                     , [ S("(")
+                       , t1__'
+                       , S(")")
+                       ]
+                     )
+                   ]
+    with t1__' := <pp-H-list(prettyprint-Term|", ")> t1__
+
+  is-Term =
+    ?Tuple(_)
+
+  prettyprint-Term :
+    List(t1__) -> [ H(
+                      [SOpt(HS(), "0")]
+                    , [ S("[")
+                      , t1__'
+                      , S("]")
+                      ]
+                    )
+                  ]
+    with t1__' := <pp-H-list(prettyprint-Term|", ")> t1__
+
+  is-Term =
+    ?List(_)
+
+  prettyprint-Term :
+    ListTail(t1__, t2__) -> [ H(
+                                [SOpt(HS(), "0")]
+                              , [ S("[")
+                                , t1__'
+                                , S(" | ")
+                                , t2__'
+                                , S("]")
+                                ]
+                              )
+                            ]
+    with t1__' := <pp-H-list(prettyprint-Term|", ")> t1__
+    with t2__' := <pp-one-Z(prettyprint-Term)> t2__
+
+  is-Term =
+    ?ListTail(_, _)
+
+  is-Term =
+    fail
+
+  prettyprint-Term :
+    amb([h|hs]) -> <prettyprint-Term> h

--- a/Xtext/nabl/src-gen/pp/terms/Vars-pp.str
+++ b/Xtext/nabl/src-gen/pp/terms/Vars-pp.str
@@ -1,0 +1,109 @@
+module nabl/src-gen/pp/terms/Vars-pp
+
+imports
+  libstratego-gpp
+  runtime/tmpl/pp
+  libstratego-sglr
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+imports
+  nabl/src-gen/pp/common/Identifiers-pp
+  nabl/src-gen/pp/terms/Terms-pp
+
+
+strategies
+  prettyprint-example =
+    prettyprint-Wld
+
+  prettyprint-example =
+    prettyprint-Var
+
+  prettyprint-example =
+    prettyprint-VarRef
+
+  prettyprint-Wld :
+    Wld() -> [ H(
+                 [SOpt(HS(), "0")]
+               , [S("_")]
+               )
+             ]
+
+  is-Wld =
+    ?Wld()
+
+  prettyprint-Var :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Var)
+    where t1__' := <pp-one-Z(prettyprint-Wld)> t1__
+
+  prettyprint-Var :
+    Var(t1__) -> [ H(
+                     [SOpt(HS(), "0")]
+                   , [t1__']
+                   )
+                 ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+
+  is-Var =
+    ?Var(_)
+
+  prettyprint-Var :
+    ListVar(t1__) -> [ H(
+                         [SOpt(HS(), "0")]
+                       , [t1__']
+                       )
+                     ]
+    with t1__' := <pp-one-Z(prettyprint-LId)> t1__
+
+  is-Var =
+    ?ListVar(_)
+
+  prettyprint-VarRef :
+    VarRef(t1__) -> [ H(
+                        [SOpt(HS(), "0")]
+                      , [t1__']
+                      )
+                    ]
+    with t1__' := <pp-one-Z(prettyprint-Id)> t1__
+
+  is-VarRef =
+    ?VarRef(_)
+
+  prettyprint-VarRef :
+    ListVarRef(t1__) -> [ H(
+                            [SOpt(HS(), "0")]
+                          , [t1__']
+                          )
+                        ]
+    with t1__' := <pp-one-Z(prettyprint-LId)> t1__
+
+  is-VarRef =
+    ?ListVarRef(_)
+
+  is-Wld =
+    fail
+
+  is-Var =
+    fail
+
+  is-VarRef =
+    fail
+
+  prettyprint-Wld :
+    amb([h|hs]) -> <prettyprint-Wld> h
+
+  prettyprint-Var :
+    amb([h|hs]) -> <prettyprint-Var> h
+
+  prettyprint-VarRef :
+    amb([h|hs]) -> <prettyprint-VarRef> h

--- a/Xtext/nabl/src-gen/signatures/NameBindingLanguage-sig.str
+++ b/Xtext/nabl/src-gen/signatures/NameBindingLanguage-sig.str
@@ -1,0 +1,80 @@
+module nabl/src-gen/signatures/NameBindingLanguage-sig
+
+imports
+  nabl/src-gen/signatures/common/Layout-sig
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Signatures-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Formulas-sig
+  nabl/src-gen/signatures/formulas/Propositions-sig
+  nabl/src-gen/signatures/core/Modules-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/core/Properties-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+signature
+  constructors
+     : Module -> Start
+
+  constructors
+    Restricted : List(Restriction) * NamespaceRef -> RestrictedNamespaceRef
+    Imported   : Restriction
+
+  constructors
+    QualityDef      : PropertyID * List(NamespaceRef) -> PropertyDef
+    QualityRef      : PropertyID -> QualityRef
+    PropertyTerm    : PropertyRef * Term -> PropertyTerm
+    QualityTerm     : QualityRef -> PropertyTerm
+    PropertyPattern : PropFilter * PropertyRef * Term -> PropertyPattern
+    QualityPattern  : QualityRef -> PropertyPattern
+    Equal           : PropFilter
+    Conformant      : PropFilter
+
+  constructors
+     : String -> SectionKeyword
+
+  constructors
+    Bindings    : List(BindingRule) -> ModuleSection
+    BindingRule : Pattern * Constraints * List(BindingClause) -> BindingRule
+
+  constructors
+    DefClause                : DefKind * Unique * NamespaceRef * Term * List(PropertyTerm) * InDefScopes * Constraints -> BindingClause
+    Explicit                 : DefKind
+    Implicit                 : DefKind
+    Unique                   : Unique
+    Unique                   : Unique
+    NonUnique                : Unique
+    ScopeClause              : List(NamespaceRef) -> BindingClause
+    NonTransitiveScopeClause : List(NamespaceRef) -> BindingClause
+    RefClause                : List(RefClausePart) -> BindingClause
+    RefClausePart            : Disambiguator * NamespaceRef * Term * List(PropertyPattern) * InRefScope * Constraints -> RefClausePart
+    ImportClause             : List(ImportClausePart) -> BindingClause
+    SingleImport             : Disambiguator * NamespaceRef * Term * List(PropertyPattern) * FromRefScope * Alias * IntoDefScopes * Constraints -> ImportClausePart
+    WildcardImport           : List(RestrictedNamespaceRef) * List(PropertyPattern) * FromRefScope * IntoDefScopes * Constraints -> ImportClausePart
+    None                     : Alias
+    Alias                    : Term -> Alias
+    FilterClause             : NamespaceRef * Term * Filters * Constraints -> BindingClause
+    DisambiguateClause       : NamespaceRef * Term * Filters * Disambiguator * Constraints -> BindingClause
+    MinimalDistance          : Term * Relation * Term -> Disambiguator
+
+  constructors
+    Current    : InDefScopes
+    Current    : IntoDefScopes
+    Current    : DefScopes
+    DefScopes  : List(DefScope) -> DefScopes
+    Subsequent : DefScope
+    DefScope   : Term -> DefScope
+    Current    : InRefScope
+    Current    : FromRefScope
+    Current    : RefScope
+    Enclosing  : NamespaceRef -> RefScope
+    Context    : Disambiguator * NamespaceRef * Term * List(PropertyPattern) * InRefScope -> RefScope
+    RefScope   : Term -> RefScope
+    All        : Disambiguator
+    Best       : Disambiguator
+
+  constructors
+    NoWhere         : Constraints
+    Filter          : Formula -> Filters
+    PropertyPattern : VarRef * PropertyRef * Pattern -> Proposition

--- a/Xtext/nabl/src-gen/signatures/common/Identifiers-sig.str
+++ b/Xtext/nabl/src-gen/signatures/common/Identifiers-sig.str
@@ -1,0 +1,17 @@
+module nabl/src-gen/signatures/common/Identifiers-sig
+
+signature
+  sorts
+    Id LId LCID UCID
+
+  constructors
+     : String -> LId
+     : String -> Id
+     : String -> LCID
+     : String -> UCID
+
+  sorts
+    Keyword
+
+  constructors
+     : String -> Keyword

--- a/Xtext/nabl/src-gen/signatures/common/Layout-sig.str
+++ b/Xtext/nabl/src-gen/signatures/common/Layout-sig.str
@@ -1,0 +1,11 @@
+module nabl/src-gen/signatures/common/Layout-sig
+
+signature
+  sorts
+    LongCom CommChar Asterisk Eof
+
+  constructors
+     : String -> Eof
+     : String -> LongCom
+     : String -> CommChar
+     : String -> Asterisk

--- a/Xtext/nabl/src-gen/signatures/core/Modules-sig.str
+++ b/Xtext/nabl/src-gen/signatures/core/Modules-sig.str
@@ -1,0 +1,13 @@
+module nabl/src-gen/signatures/core/Modules-sig
+
+signature
+  constructors
+    Module         : ModuleID * List(ModuleSection) -> Module
+    Imports        : List(ImportModule) -> ModuleSection
+    ImportWildcard : ModuleID -> ImportModule
+    Import         : ModuleID -> ImportModule
+
+  constructors
+     : String -> ModuleID
+     : String -> ModuleIDPart
+     : String -> SectionKeyword

--- a/Xtext/nabl/src-gen/signatures/core/Namespaces-sig.str
+++ b/Xtext/nabl/src-gen/signatures/core/Namespaces-sig.str
@@ -1,0 +1,18 @@
+module nabl/src-gen/signatures/core/Namespaces-sig
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/core/Modules-sig
+
+
+signature
+  constructors
+     : String -> NamespaceID
+     : String -> SectionKeyword
+
+  constructors
+    Namespaces      : List(NamespaceDef) -> ModuleSection
+    NamespaceDef    : NamespaceID -> NamespaceDef
+    NamespaceRef    : LanguageRef * NamespaceID -> NamespaceRef
+    CurrentLanguage : LanguageRef
+    LanguageRef     : Id -> LanguageRef

--- a/Xtext/nabl/src-gen/signatures/core/Properties-sig.str
+++ b/Xtext/nabl/src-gen/signatures/core/Properties-sig.str
@@ -1,0 +1,22 @@
+module nabl/src-gen/signatures/core/Properties-sig
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Signatures-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Formulas-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+
+
+signature
+  constructors
+     : String -> PropertyID
+     : String -> SectionKeyword
+     : String -> Relation
+
+  constructors
+    Properties  : List(PropertyDef) -> ModuleSection
+    PropertyDef : PropertyID * List(NamespaceRef) * Sort -> PropertyDef
+    TypeProp    : PropertyRef
+    PropertyRef : PropertyID -> PropertyRef

--- a/Xtext/nabl/src-gen/signatures/core/Scopes-sig.str
+++ b/Xtext/nabl/src-gen/signatures/core/Scopes-sig.str
@@ -1,0 +1,25 @@
+module nabl/src-gen/signatures/core/Scopes-sig
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+signature
+  constructors
+     : String -> ScopeID
+
+  constructors
+    NamedScope   : NamespaceRef * VarRef -> LocalScope
+    CurrentScope : NamespaceRef -> LocalScope
+    TermScope    : NamespaceRef * VarRef -> LocalScope
+    Enclosing    : NamespaceRef * LocalScope -> LocalScope
+    GlobalScope  : Scope
+                 : LocalScope -> Scope
+    Anonymous    : Scope -> Scope
+
+  constructors
+    ChildScope      : Scope * NamespaceRef -> Clause
+    SubsequentScope : Scope * NamespaceRef -> Clause
+    NodeScope       : NamespaceRef * VarRef -> Clause

--- a/Xtext/nabl/src-gen/signatures/formulas/Formulas-sig.str
+++ b/Xtext/nabl/src-gen/signatures/formulas/Formulas-sig.str
@@ -1,0 +1,13 @@
+module nabl/src-gen/signatures/formulas/Formulas-sig
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/formulas/Propositions-sig
+
+
+signature
+  constructors
+        : Proposition -> Formula
+    Not : Formula -> Formula
+    And : Formula * Formula -> Formula
+    Or  : Formula * Formula -> Formula

--- a/Xtext/nabl/src-gen/signatures/formulas/Messages-sig.str
+++ b/Xtext/nabl/src-gen/signatures/formulas/Messages-sig.str
@@ -1,0 +1,12 @@
+module nabl/src-gen/signatures/formulas/Messages-sig
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+signature
+  constructors
+    Message : MessageKind * Term * Term -> Message
+    Error   : MessageKind
+    Warning : MessageKind
+    Note    : MessageKind

--- a/Xtext/nabl/src-gen/signatures/formulas/Propositions-sig.str
+++ b/Xtext/nabl/src-gen/signatures/formulas/Propositions-sig.str
@@ -1,0 +1,22 @@
+module nabl/src-gen/signatures/formulas/Propositions-sig
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+  nabl/src-gen/signatures/core/Namespaces-sig
+  nabl/src-gen/signatures/core/Scopes-sig
+  nabl/src-gen/signatures/core/Properties-sig
+
+
+signature
+  constructors
+    True        : Proposition
+    False       : Proposition
+    Eq          : VarRef * Term -> Proposition
+    Match       : VarRef * Pattern -> Proposition
+    DefOf       : VarRef * Var -> Proposition
+    DefOf       : NamespaceRef * VarRef * Var -> Proposition
+    ScopeOf     : Scope * Var -> Proposition
+    ResolvesTo  : Term * NamespaceRef * Var -> Proposition
+    HasProperty : VarRef * PropertyRef * Var -> Proposition
+    InRelation  : Term * Relation * Term -> Proposition

--- a/Xtext/nabl/src-gen/signatures/lexical/Identifiers-sig.str
+++ b/Xtext/nabl/src-gen/signatures/lexical/Identifiers-sig.str
@@ -1,0 +1,13 @@
+module nabl/src-gen/signatures/lexical/Identifiers-sig
+
+signature
+  sorts
+    Id LId LCID UCID ModuleID
+
+  constructors
+     : String -> Id
+     : String -> LId
+     : String -> LCID
+     : String -> UCID
+     : String -> ModuleID
+     : String -> ModuleIDPart

--- a/Xtext/nabl/src-gen/signatures/lexical/Layout-sig.str
+++ b/Xtext/nabl/src-gen/signatures/lexical/Layout-sig.str
@@ -1,0 +1,11 @@
+module nabl/src-gen/signatures/lexical/Layout-sig
+
+signature
+  sorts
+    LongCom CommChar Asterisk Eof
+
+  constructors
+     : String -> Eof
+     : String -> LongCom
+     : String -> CommChar
+     : String -> Asterisk

--- a/Xtext/nabl/src-gen/signatures/terms/Constants-sig.str
+++ b/Xtext/nabl/src-gen/signatures/terms/Constants-sig.str
@@ -1,0 +1,18 @@
+module nabl/src-gen/signatures/terms/Constants-sig
+
+signature
+  sorts
+    Int Real String StrChar
+
+  constructors
+     : String -> Int
+     : String -> Real
+     : String -> String
+     : String -> StrChar
+
+  sorts
+    Char CharChar
+
+  constructors
+     : String -> Char
+     : String -> CharChar

--- a/Xtext/nabl/src-gen/signatures/terms/Signatures-sig.str
+++ b/Xtext/nabl/src-gen/signatures/terms/Signatures-sig.str
@@ -1,0 +1,31 @@
+module nabl/src-gen/signatures/terms/Signatures-sig
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Constants-sig
+
+
+signature
+  sorts
+    Sort
+
+  constructors
+    SortVar    : LCID -> Sort
+    SortNoArgs : UCID -> Sort
+    Sort       : Id * List(Sort) -> Sort
+
+  sorts
+    TypeDecl PPTerm
+
+  constructors
+    TypeDecl  : Id * TypeParams * PPTerm -> TypeDecl
+    TypeDeclQ : String * TypeParams * PPTerm -> TypeDecl
+    Str       : String -> PPTerm
+
+  sorts
+    TypeParams TypeParam
+
+  constructors
+    NoTypeParams : TypeParams
+    TypeParams   : List(TypeParam) -> TypeParams
+    TypeParam    : Id * Sort -> TypeParam

--- a/Xtext/nabl/src-gen/signatures/terms/StringQuotations-sig.str
+++ b/Xtext/nabl/src-gen/signatures/terms/StringQuotations-sig.str
@@ -1,0 +1,46 @@
+module nabl/src-gen/signatures/terms/StringQuotations-sig
+
+imports
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+signature
+  sorts
+    PPTerm StringQuotation StringQuotedPart1 StringQuotedChars1 QuotedBracket1 Dollar1 StringQuotedPart2 StringQuotedChars2 QuotedBracket2 Dollar2 StringQuotedPart3 StringQuotedChars3 QuotedBracket3 Dollar3 StringQuotedPart4 StringQuotedChars4 QuotedBracket4 Dollar4 Padding
+
+  constructors
+                     : StringQuotation -> PPTerm
+    StringQuotation1 : Padding * List(StringQuotedPart1) -> StringQuotation
+    StringEscape1    : Padding * Term -> StringQuotedPart1
+    QStr             : StringQuotedChars1 -> StringQuotedPart1
+    QDollar          : Dollar1 -> StringQuotedPart1
+    QBr              : QuotedBracket1 -> StringQuotedPart1
+                     : StringQuotedChars1
+                     : QuotedBracket1
+                     : Dollar1
+    StringQuotation2 : Padding * List(StringQuotedPart2) -> StringQuotation
+    StringEscape2    : Padding * Term -> StringQuotedPart2
+    QStr             : StringQuotedChars2 -> StringQuotedPart2
+    QDollar          : Dollar2 -> StringQuotedPart2
+    QBr              : QuotedBracket2 -> StringQuotedPart2
+                     : StringQuotedChars2
+                     : QuotedBracket2
+                     : Dollar2
+    StringQuotation3 : Padding * List(StringQuotedPart3) -> StringQuotation
+    StringEscape3    : Padding * Term -> StringQuotedPart3
+    QStr             : StringQuotedChars3 -> StringQuotedPart3
+    QDollar          : Dollar3 -> StringQuotedPart3
+    QBr              : QuotedBracket3 -> StringQuotedPart3
+                     : StringQuotedChars3
+                     : QuotedBracket3
+                     : Dollar3
+    StringQuotation4 : Padding * List(StringQuotedPart4) -> StringQuotation
+    StringEscape4    : Padding * Term -> StringQuotedPart4
+    QStr             : StringQuotedChars4 -> StringQuotedPart4
+    QDollar          : Dollar4 -> StringQuotedPart4
+    QBr              : QuotedBracket4 -> StringQuotedPart4
+                     : StringQuotedChars4
+                     : QuotedBracket4
+                     : Dollar4
+                     : Padding -> Padding
+                     : Padding

--- a/Xtext/nabl/src-gen/signatures/terms/Terms-sig.str
+++ b/Xtext/nabl/src-gen/signatures/terms/Terms-sig.str
@@ -1,0 +1,39 @@
+module nabl/src-gen/signatures/terms/Terms-sig
+
+imports
+  nabl/src-gen/signatures/terms/Constants-sig
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Vars-sig
+
+
+signature
+  sorts
+    Pattern
+
+  constructors
+             : Var -> Pattern
+    Int      : Int -> Pattern
+    Real     : Real -> Pattern
+    Str      : String -> Pattern
+    Op       : Id * List(Pattern) -> Pattern
+    OpQ      : String * List(Pattern) -> Pattern
+    Char     : Char -> Pattern
+    Tuple    : List(Pattern) -> Pattern
+    List     : List(Pattern) -> Pattern
+    ListTail : List(Pattern) * Pattern -> Pattern
+    As       : Var * Pattern -> Pattern
+
+  sorts
+    Term
+
+  constructors
+             : VarRef -> Term
+    Int      : Int -> Term
+    Real     : Real -> Term
+    Str      : String -> Term
+    Op       : Id * List(Term) -> Term
+    OpQ      : String * List(Term) -> Term
+    Char     : Char -> Term
+    Tuple    : List(Term) -> Term
+    List     : List(Term) -> Term
+    ListTail : List(Term) * Term -> Term

--- a/Xtext/nabl/src-gen/signatures/terms/Vars-sig.str
+++ b/Xtext/nabl/src-gen/signatures/terms/Vars-sig.str
@@ -1,0 +1,18 @@
+module nabl/src-gen/signatures/terms/Vars-sig
+
+imports
+  nabl/src-gen/signatures/common/Identifiers-sig
+  nabl/src-gen/signatures/terms/Terms-sig
+
+
+signature
+  sorts
+    Wld Var VarRef
+
+  constructors
+    Wld        : Wld
+               : Wld -> Var
+    Var        : Id -> Var
+    ListVar    : LId -> Var
+    VarRef     : Id -> VarRef
+    ListVarRef : LId -> VarRef

--- a/Xtext/nabl/src-gen/syntax/NameBindingLanguage.sdf
+++ b/Xtext/nabl/src-gen/syntax/NameBindingLanguage.sdf
@@ -1,0 +1,143 @@
+module NameBindingLanguage
+imports common/Layout common/Identifiers terms/Signatures terms/Terms
+        formulas/Formulas formulas/Propositions core/Modules core/Namespaces
+        core/Properties terms/Vars
+
+exports
+  context-free start-symbols
+    Start
+
+  context-free syntax
+    Module -> Start 
+
+  context-free syntax
+    Restriction* NamespaceRef -> RestrictedNamespaceRef {cons("Restricted")}
+    "imported"                -> Restriction            {cons("Imported")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> RestrictedNamespaceRef {cons("COMPLETION-RestrictedNamespaceRef")}
+    CONTENTCOMPLETE -> Restriction            {cons("COMPLETION-Restriction")}
+
+  lexical restrictions
+    "imported" -/- [a-zA-z]
+
+  context-free syntax
+    PropertyID "of" {NamespaceRef ","}+ -> PropertyDef     {cons("QualityDef")}
+    PropertyID                          -> QualityRef      {cons("QualityRef")}
+    "of" PropertyRef Term               -> PropertyTerm    {cons("PropertyTerm")}
+    "of" "quality" QualityRef           -> PropertyTerm    {cons("QualityTerm")}
+    "of" PropFilter PropertyRef Term    -> PropertyPattern {cons("PropertyPattern")}
+    "of" "quality" QualityRef           -> PropertyPattern {cons("QualityPattern")}
+                                        -> PropFilter      {cons("Equal")}
+    "conformant"                        -> PropFilter      {cons("Conformant")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> PropertyDef     {cons("COMPLETION-PropertyDef")}
+    CONTENTCOMPLETE -> QualityRef      {cons("COMPLETION-QualityRef")}
+    CONTENTCOMPLETE -> PropertyTerm    {cons("COMPLETION-PropertyTerm")}
+    CONTENTCOMPLETE -> PropertyPattern {cons("COMPLETION-PropertyPattern")}
+    CONTENTCOMPLETE -> PropFilter      {cons("COMPLETION-PropFilter")}
+
+  lexical restrictions
+    "of" "quality" "conformant" -/- [a-zA-z]
+
+  lexical syntax
+    "quality" -> PropertyID     {reject}
+    "binding" -> SectionKeyword 
+
+  context-free syntax
+    "binding" "rules" BindingRule*         -> ModuleSection {cons("Bindings")}
+    Pattern Constraints ":" BindingClause+ -> BindingRule   {cons("BindingRule")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> ModuleSection {cons("COMPLETION-ModuleSection")}
+    CONTENTCOMPLETE -> BindingRule   {cons("COMPLETION-BindingRule")}
+
+  lexical restrictions
+    "binding" "rules" -/- [a-zA-z]
+
+  context-free syntax
+    DefKind "defines" Unique NamespaceRef Term PropertyTerm* InDefScopes Constraints                        -> BindingClause    {cons("DefClause")}
+                                                                                                            -> DefKind          {cons("Explicit")}
+    "implicitly"                                                                                            -> DefKind          {cons("Implicit")}
+                                                                                                            -> Unique           {cons("Unique")}
+    "unique"                                                                                                -> Unique           {cons("Unique")}
+    "non-unique"                                                                                            -> Unique           {cons("NonUnique")}
+    "scopes" {NamespaceRef ","}+                                                                            -> BindingClause    {cons("ScopeClause")}
+    "non-transitively" "scopes" {NamespaceRef ","}+                                                         -> BindingClause    {cons("NonTransitiveScopeClause")}
+    {RefClausePart "otherwise"}+                                                                            -> BindingClause    {cons("RefClause")}
+    "refers" "to" Disambiguator NamespaceRef Term PropertyPattern* InRefScope Constraints                   -> RefClausePart    {cons("RefClausePart")}
+    {ImportClausePart "otherwise"}+                                                                         -> BindingClause    {cons("ImportClause")}
+    "imports" Disambiguator NamespaceRef Term PropertyPattern* FromRefScope Alias IntoDefScopes Constraints -> ImportClausePart {cons("SingleImport")}
+    "imports" {RestrictedNamespaceRef ","}+ PropertyPattern* FromRefScope IntoDefScopes Constraints         -> ImportClausePart {cons("WildcardImport")}
+                                                                                                            -> Alias            {cons("None")}
+    "as" Term                                                                                               -> Alias            {cons("Alias")}
+    "filters" NamespaceRef Term Filters Constraints                                                         -> BindingClause    {cons("FilterClause")}
+    "disambiguates" NamespaceRef Term Filters "by" Disambiguator Constraints                                -> BindingClause    {cons("DisambiguateClause")}
+    "minimal" "distance" Term Relation Term                                                                 -> Disambiguator    {cons("MinimalDistance")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> DefKind          {cons("COMPLETION-DefKind")}
+    CONTENTCOMPLETE -> Unique           {cons("COMPLETION-Unique")}
+    CONTENTCOMPLETE -> RefClausePart    {cons("COMPLETION-RefClausePart")}
+    CONTENTCOMPLETE -> ImportClausePart {cons("COMPLETION-ImportClausePart")}
+    CONTENTCOMPLETE -> Alias            {cons("COMPLETION-Alias")}
+    CONTENTCOMPLETE -> BindingClause    {cons("COMPLETION-BindingClause")}
+    CONTENTCOMPLETE -> Disambiguator    {cons("COMPLETION-Disambiguator")}
+
+  lexical restrictions
+    "defines" "implicitly" "unique" "non-unique" "non-transitively" "scopes"
+    "refers" "to" "imports" "as" "filters" "disambiguates" "by" "minimal"
+    "distance" -/- [a-zA-z]
+
+  context-free syntax
+                                                                -> InDefScopes   {cons("Current")}
+    "in" DefScopes                                              -> InDefScopes   {bracket}
+                                                                -> IntoDefScopes {cons("Current")}
+    "into" DefScopes                                            -> IntoDefScopes {bracket}
+    "current" "scope"                                           -> DefScopes     {cons("Current")}
+    {DefScope ","}+                                             -> DefScopes     {cons("DefScopes")}
+    "subsequent" "scope"                                        -> DefScope      {cons("Subsequent")}
+    Term                                                        -> DefScope      {cons("DefScope")}
+                                                                -> InRefScope    {cons("Current")}
+    "in" RefScope                                               -> InRefScope    {bracket}
+                                                                -> FromRefScope  {cons("Current")}
+    "from" RefScope                                             -> FromRefScope  {bracket}
+    "current" "scope"                                           -> RefScope      {cons("Current")}
+    "enclosing" NamespaceRef                                    -> RefScope      {cons("Enclosing")}
+    Disambiguator NamespaceRef Term PropertyPattern* InRefScope -> RefScope      {cons("Context")}
+    Term                                                        -> RefScope      {cons("RefScope")}
+                                                                -> Disambiguator {cons("All")}
+    "best"                                                      -> Disambiguator {cons("Best")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> InDefScopes   {cons("COMPLETION-InDefScopes")}
+    CONTENTCOMPLETE -> IntoDefScopes {cons("COMPLETION-IntoDefScopes")}
+    CONTENTCOMPLETE -> DefScopes     {cons("COMPLETION-DefScopes")}
+    CONTENTCOMPLETE -> DefScope      {cons("COMPLETION-DefScope")}
+    CONTENTCOMPLETE -> InRefScope    {cons("COMPLETION-InRefScope")}
+    CONTENTCOMPLETE -> FromRefScope  {cons("COMPLETION-FromRefScope")}
+    CONTENTCOMPLETE -> RefScope      {cons("COMPLETION-RefScope")}
+    CONTENTCOMPLETE -> Disambiguator {cons("COMPLETION-Disambiguator")}
+
+  lexical restrictions
+    "into" "subsequent" "in" "from" "current" "scope" "enclosing" "best"
+    -/- [a-zA-z]
+
+  context-free syntax
+                                     -> Constraints {cons("NoWhere")}
+    "where" Formula                  -> Constraints {cons("Where"), bracket}
+    "with" Formula                   -> Filters     {cons("Filter")}
+    VarRef "has" PropertyRef Pattern -> Proposition {cons("PropertyPattern"), avoid}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Constraints {cons("COMPLETION-Constraints")}
+    CONTENTCOMPLETE -> Filters     {cons("COMPLETION-Filters")}
+    CONTENTCOMPLETE -> Proposition {cons("COMPLETION-Proposition")}
+
+  lexical restrictions
+    "where" "with" "has" -/- [a-zA-z]
+
+  lexical syntax
+    "into"      -> Id {reject}
+    "enclosing" -> Id {reject}

--- a/Xtext/nabl/src-gen/syntax/common/Identifiers.sdf
+++ b/Xtext/nabl/src-gen/syntax/common/Identifiers.sdf
@@ -1,0 +1,33 @@
+module common/Identifiers
+exports
+  sorts Id LId LCID UCID
+
+  lexical syntax
+    [a-zA-Z\_] [a-zA-Z0-9\'\-\_]*     -> Id   
+    [a-zA-Z\_] [a-zA-Z0-9\'\-\_]* "*" -> LId  
+    [\'] [a-z]+                       -> Id   
+    [a-z] [a-zA-Z0-9\'\-\_]*          -> LCID 
+    [A-Z] [a-zA-Z0-9\'\-\_]*          -> UCID 
+
+  lexical restrictions
+    Id -/- [a-zA-Z0-9\'\_\*]
+    Id -/- [\-] . ~[\>]
+    LId -/- [a-zA-Z0-9\'\-\_]
+    LCID -/- [a-zA-Z0-9\'\-\_]
+    UCID -/- [a-zA-Z0-9\'\-\_]
+
+  lexical syntax
+    "_"     -> Id   {reject}
+    "'"     -> Id   {reject}
+    Keyword -> Id   {reject}
+    Keyword -> LId  {reject}
+    Keyword -> LCID {reject}
+    Keyword -> UCID {reject}
+
+  sorts Keyword
+
+  lexical syntax
+    "module"     -> Keyword 
+    "rules"      -> Keyword 
+    "namespaces" -> Keyword 
+    "properties" -> Keyword 

--- a/Xtext/nabl/src-gen/syntax/common/Layout.sdf
+++ b/Xtext/nabl/src-gen/syntax/common/Layout.sdf
@@ -1,0 +1,22 @@
+module common/Layout
+exports
+  sorts LongCom CommChar Asterisk Eof
+
+  lexical syntax
+    [\t\ \n\r]             -> LAYOUT   
+    "//" ~[\n]* [\n] | Eof -> LAYOUT   
+                           -> Eof      
+    LongCom                -> LAYOUT   
+    "/*" CommChar* "*/"    -> LongCom  
+    ~[\*]                  -> CommChar 
+    Asterisk               -> CommChar 
+    "*"                    -> Asterisk 
+
+  lexical restrictions
+    Asterisk -/- [\/]
+    Eof -/- ~[]
+
+  context-free restrictions
+    LAYOUT? -/- [\ \t\n\r]
+    LAYOUT? -/- [\/] . [\*]
+    LAYOUT? -/- [\/] . [\/]

--- a/Xtext/nabl/src-gen/syntax/core/Modules.sdf
+++ b/Xtext/nabl/src-gen/syntax/core/Modules.sdf
@@ -1,0 +1,21 @@
+module core/Modules
+exports
+  context-free syntax
+    "module" ModuleID ModuleSection* -> Module        {cons("Module")}
+    "imports" ImportModule*          -> ModuleSection {cons("Imports")}
+    ModuleID "/-"                    -> ImportModule  {cons("ImportWildcard")}
+    ModuleID                         -> ImportModule  {cons("Import")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Module        {cons("COMPLETION-Module")}
+    CONTENTCOMPLETE -> ModuleSection {cons("COMPLETION-ModuleSection")}
+    CONTENTCOMPLETE -> ImportModule  {cons("COMPLETION-ImportModule")}
+
+  lexical syntax
+    {ModuleIDPart "/"}+               -> ModuleID       
+    [a-zA-Z\.\_] [a-zA-Z0-9\'\.\-\_]* -> ModuleIDPart   
+    SectionKeyword                    -> ModuleID       {reject}
+    "imports"                         -> SectionKeyword 
+
+  lexical restrictions
+    ModuleID -/- [a-zA-Z0-9\'\.\-\_]

--- a/Xtext/nabl/src-gen/syntax/core/Namespaces.sdf
+++ b/Xtext/nabl/src-gen/syntax/core/Namespaces.sdf
@@ -1,0 +1,21 @@
+module core/Namespaces
+imports common/Identifiers core/Modules
+
+exports
+  lexical syntax
+    Id             -> NamespaceID    
+    SectionKeyword -> NamespaceID    {reject}
+    "namespaces"   -> SectionKeyword 
+
+  context-free syntax
+    "namespaces" NamespaceDef* -> ModuleSection {cons("Namespaces")}
+    NamespaceID                -> NamespaceDef  {cons("NamespaceDef")}
+    LanguageRef NamespaceID    -> NamespaceRef  {cons("NamespaceRef")}
+                               -> LanguageRef   {cons("CurrentLanguage")}
+    Id "."                     -> LanguageRef   {cons("LanguageRef")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> ModuleSection {cons("COMPLETION-ModuleSection")}
+    CONTENTCOMPLETE -> NamespaceDef  {cons("COMPLETION-NamespaceDef")}
+    CONTENTCOMPLETE -> NamespaceRef  {cons("COMPLETION-NamespaceRef")}
+    CONTENTCOMPLETE -> LanguageRef   {cons("COMPLETION-LanguageRef")}

--- a/Xtext/nabl/src-gen/syntax/core/Properties.sdf
+++ b/Xtext/nabl/src-gen/syntax/core/Properties.sdf
@@ -1,0 +1,22 @@
+module core/Properties
+imports common/Identifiers terms/Signatures terms/Vars terms/Terms
+        formulas/Formulas core/Namespaces
+
+exports
+  lexical syntax
+    Id                  -> PropertyID     
+    "type"              -> PropertyID     {reject}
+    SectionKeyword      -> PropertyID     {reject}
+    "properties"        -> SectionKeyword 
+    "<" [A-Za-z\-]* ":" -> Relation       
+
+  context-free syntax
+    "properties" PropertyDef*                    -> ModuleSection {cons("Properties")}
+    PropertyID "of" {NamespaceRef ","}+ ":" Sort -> PropertyDef   {cons("PropertyDef")}
+    "type"                                       -> PropertyRef   {cons("TypeProp")}
+    PropertyID                                   -> PropertyRef   {cons("PropertyRef")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> ModuleSection {cons("COMPLETION-ModuleSection")}
+    CONTENTCOMPLETE -> PropertyDef   {cons("COMPLETION-PropertyDef")}
+    CONTENTCOMPLETE -> PropertyRef   {cons("COMPLETION-PropertyRef")}

--- a/Xtext/nabl/src-gen/syntax/core/Scopes.sdf
+++ b/Xtext/nabl/src-gen/syntax/core/Scopes.sdf
@@ -1,0 +1,27 @@
+module core/Scopes
+imports common/Identifiers core/Namespaces terms/Vars
+
+exports
+  lexical syntax
+    Id -> ScopeID 
+
+  context-free syntax
+    NamespaceRef VarRef                      -> LocalScope {cons("NamedScope")}
+    "current" NamespaceRef "scope"           -> LocalScope {cons("CurrentScope")}
+    NamespaceRef "scope" "at" VarRef         -> LocalScope {cons("TermScope")}
+    "enclosing" NamespaceRef "of" LocalScope -> LocalScope {cons("Enclosing")}
+    "global" "scope"                         -> Scope      {cons("GlobalScope")}
+    LocalScope                               -> Scope      
+    "new" "scope" "in" Scope                 -> Scope      {cons("Anonymous")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> LocalScope {cons("COMPLETION-LocalScope")}
+    CONTENTCOMPLETE -> Scope      {cons("COMPLETION-Scope")}
+
+  context-free syntax
+    Scope "scopes" NamespaceRef "at" "child" "nodes"      -> Clause {cons("ChildScope")}
+    Scope "scopes" NamespaceRef "at" "subsequent" "nodes" -> Clause {cons("SubsequentScope")}
+    "requires" NamespaceRef "scope" "at" VarRef           -> Clause {cons("NodeScope")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Clause {cons("COMPLETION-Clause")}

--- a/Xtext/nabl/src-gen/syntax/formulas/Formulas.sdf
+++ b/Xtext/nabl/src-gen/syntax/formulas/Formulas.sdf
@@ -1,0 +1,18 @@
+module formulas/Formulas
+imports terms/Terms formulas/Propositions
+
+exports
+  context-free syntax
+    Proposition           -> Formula 
+    "not" Formula         -> Formula {cons("Not")}
+    Formula "and" Formula -> Formula {cons("And"), left}
+    Formula "or" Formula  -> Formula {cons("Or"), left}
+    "(" Formula ")"       -> Formula {bracket}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Formula {cons("COMPLETION-Formula")}
+
+  context-free priorities
+    "not" Formula -> Formula >
+    Formula "and" Formula -> Formula >
+    Formula "or" Formula -> Formula

--- a/Xtext/nabl/src-gen/syntax/formulas/Messages.sdf
+++ b/Xtext/nabl/src-gen/syntax/formulas/Messages.sdf
@@ -1,0 +1,13 @@
+module formulas/Messages
+imports terms/Terms
+
+exports
+  context-free syntax
+    MessageKind Term "on" Term -> Message     {cons("Message")}
+    "error"                    -> MessageKind {cons("Error")}
+    "warning"                  -> MessageKind {cons("Warning")}
+    "note"                     -> MessageKind {cons("Note")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Message     {cons("COMPLETION-Message")}
+    CONTENTCOMPLETE -> MessageKind {cons("COMPLETION-MessageKind")}

--- a/Xtext/nabl/src-gen/syntax/formulas/Propositions.sdf
+++ b/Xtext/nabl/src-gen/syntax/formulas/Propositions.sdf
@@ -1,0 +1,18 @@
+module formulas/Propositions
+imports terms/Terms terms/Vars core/Namespaces core/Scopes core/Properties
+
+exports
+  context-free syntax
+    "true"                                         -> Proposition {cons("True")}
+    "false"                                        -> Proposition {cons("False")}
+    VarRef "==" Term                               -> Proposition {cons("Eq")}
+    VarRef "=>" Pattern                            -> Proposition {cons("Match")}
+    "definition" "of" VarRef "=>" Var              -> Proposition {cons("DefOf")}
+    "definition" "of" NamespaceRef VarRef "=>" Var -> Proposition {cons("DefOf")}
+    Scope "=>" Var                                 -> Proposition {cons("ScopeOf")}
+    Term "resolves" "to" NamespaceRef Var          -> Proposition {cons("ResolvesTo")}
+    VarRef "has" PropertyRef Var                   -> Proposition {cons("HasProperty")}
+    Term Relation Term                             -> Proposition {cons("InRelation")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Proposition {cons("COMPLETION-Proposition")}

--- a/Xtext/nabl/src-gen/syntax/lexical/Identifiers.sdf
+++ b/Xtext/nabl/src-gen/syntax/lexical/Identifiers.sdf
@@ -1,0 +1,21 @@
+module lexical/Identifiers
+exports
+  sorts Id LId LCID UCID ModuleID
+
+  lexical syntax
+    [a-zA-Z\_] [a-zA-Z0-9\'\-\_]*     -> Id           
+    "_"                               -> Id           {reject}
+    [\'] [a-z]+                       -> Id           
+    [a-zA-Z\_] [a-zA-Z0-9\'\-\_]* "*" -> LId          
+    [a-z] [a-zA-Z0-9\'\-\_]*          -> LCID         
+    [A-Z] [a-zA-Z0-9\'\-\_]*          -> UCID         
+    {ModuleIDPart "/"}+               -> ModuleID     
+    [a-zA-Z\.\_] [a-zA-Z0-9\'\.\-\_]* -> ModuleIDPart 
+
+  lexical restrictions
+    Id -/- [a-zA-Z0-9\'\_\*]
+    Id -/- [\-] . ~[\>]
+    LId -/- [a-zA-Z0-9\'\-\_]
+    LCID -/- [a-zA-Z0-9\'\-\_]
+    UCID -/- [a-zA-Z0-9\'\-\_]
+    ModuleID -/- [a-zA-Z0-9\'\.\-\_]

--- a/Xtext/nabl/src-gen/syntax/lexical/Layout.sdf
+++ b/Xtext/nabl/src-gen/syntax/lexical/Layout.sdf
@@ -1,0 +1,22 @@
+module lexical/Layout
+exports
+  sorts LongCom CommChar Asterisk Eof
+
+  lexical syntax
+    [\t\ \n\r]             -> LAYOUT   
+    "//" ~[\n]* [\n] | Eof -> LAYOUT   
+                           -> Eof      
+    LongCom                -> LAYOUT   
+    "/*" CommChar* "*/"    -> LongCom  
+    ~[\*]                  -> CommChar 
+    Asterisk               -> CommChar 
+    "*"                    -> Asterisk 
+
+  lexical restrictions
+    Asterisk -/- [\/]
+    Eof -/- ~[]
+
+  context-free restrictions
+    LAYOUT? -/- [\ \t\n\r]
+    LAYOUT? -/- [\/] . [\*]
+    LAYOUT? -/- [\/] . [\/]

--- a/Xtext/nabl/src-gen/syntax/terms/Constants.sdf
+++ b/Xtext/nabl/src-gen/syntax/terms/Constants.sdf
@@ -1,0 +1,20 @@
+module terms/Constants
+exports
+  sorts Int Real String StrChar
+
+  lexical syntax
+    [\-]? [0-9]+             -> Int     
+    [\-]? [0-9]+ [\.] [0-9]+ -> Real    
+    "\"" StrChar* "\""       -> String  
+    ~[\"\\]                  -> StrChar 
+    [\\] [\"tnr\\]           -> StrChar 
+
+  sorts Char CharChar
+
+  lexical syntax
+    "'" CharChar "'" -> Char     
+    ~[\']            -> CharChar 
+    [\\] [\'ntr\ ]   -> CharChar 
+
+  lexical syntax
+    Char -> Id {reject}

--- a/Xtext/nabl/src-gen/syntax/terms/Signatures.sdf
+++ b/Xtext/nabl/src-gen/syntax/terms/Signatures.sdf
@@ -1,0 +1,27 @@
+module terms/Signatures
+imports common/Identifiers terms/Constants
+
+exports
+  sorts Sort
+
+  context-free syntax
+    LCID                   -> Sort {cons("SortVar")}
+    UCID                   -> Sort {cons("SortNoArgs")}
+    Id "(" {Sort ","}* ")" -> Sort {cons("Sort")}
+
+  sorts TypeDecl PPTerm
+
+  context-free syntax
+    Id TypeParams PPTerm     -> TypeDecl {cons("TypeDecl")}
+    String TypeParams PPTerm -> TypeDecl {cons("TypeDeclQ")}
+    String                   -> PPTerm   {cons("Str")}
+
+  sorts TypeParams TypeParam
+
+  context-free syntax
+                             -> TypeParams {cons("NoTypeParams")}
+    "(" {TypeParam ","}+ ")" -> TypeParams {cons("TypeParams")}
+    Id ":" Sort              -> TypeParam  {cons("TypeParam")}
+
+  context-free restrictions
+    Sort -/- [\(]

--- a/Xtext/nabl/src-gen/syntax/terms/StringQuotations.sdf
+++ b/Xtext/nabl/src-gen/syntax/terms/StringQuotations.sdf
@@ -1,0 +1,56 @@
+module terms/StringQuotations
+imports terms/Terms
+
+exports
+  sorts PPTerm StringQuotation StringQuotedPart1 StringQuotedChars1
+        QuotedBracket1 Dollar1 StringQuotedPart2 StringQuotedChars2
+        QuotedBracket2 Dollar2 StringQuotedPart3 StringQuotedChars3
+        QuotedBracket3 Dollar3 StringQuotedPart4 StringQuotedChars4
+        QuotedBracket4 Dollar4 Padding
+
+  syntax
+    StringQuotation                                     -> <PPTerm-CF>              
+    "$" "[" Padding StringQuotedPart1* "]"              -> StringQuotation          {cons("StringQuotation1")}
+    Padding "[" <LAYOUT?-CF> <Term-CF> <LAYOUT?-CF> "]" -> StringQuotedPart1        {cons("StringEscape1")}
+    <StringQuotedChars1-LEX>                            -> StringQuotedPart1        {cons("QStr")}
+    <Dollar1-LEX>                                       -> StringQuotedPart1        {cons("QDollar")}
+    "$" <QuotedBracket1-LEX> "$"                        -> StringQuotedPart1        {cons("QBr")}
+    ~[\[\]\$]+                                          -> <StringQuotedChars1-LEX> 
+    [\[\]]                                              -> <QuotedBracket1-LEX>     
+    "$"                                                 -> <Dollar1-LEX>            
+    "$" "{" Padding StringQuotedPart2* "}"              -> StringQuotation          {cons("StringQuotation2")}
+    Padding "{" <LAYOUT?-CF> <Term-CF> <LAYOUT?-CF> "}" -> StringQuotedPart2        {cons("StringEscape2")}
+    <StringQuotedChars2-LEX>                            -> StringQuotedPart2        {cons("QStr")}
+    <Dollar2-LEX>                                       -> StringQuotedPart2        {cons("QDollar")}
+    "$" <QuotedBracket2-LEX> "$"                        -> StringQuotedPart2        {cons("QBr")}
+    ~[\{\}\$]+                                          -> <StringQuotedChars2-LEX> 
+    [\{\}]                                              -> <QuotedBracket2-LEX>     
+    "$"                                                 -> <Dollar2-LEX>            
+    "$" "(" Padding StringQuotedPart3* ")"              -> StringQuotation          {cons("StringQuotation3")}
+    Padding "(" <LAYOUT?-CF> <Term-CF> <LAYOUT?-CF> ")" -> StringQuotedPart3        {cons("StringEscape3")}
+    <StringQuotedChars3-LEX>                            -> StringQuotedPart3        {cons("QStr")}
+    <Dollar3-LEX>                                       -> StringQuotedPart3        {cons("QDollar")}
+    "$" <QuotedBracket3-LEX> "$"                        -> StringQuotedPart3        {cons("QBr")}
+    ~[\(\)\$]+                                          -> <StringQuotedChars3-LEX> 
+    [\(\)]                                              -> <QuotedBracket3-LEX>     
+    "$"                                                 -> <Dollar3-LEX>            
+    "$" "<" Padding StringQuotedPart4* ">"              -> StringQuotation          {cons("StringQuotation4")}
+    Padding "<" <LAYOUT?-CF> <Term-CF> <LAYOUT?-CF> ">" -> StringQuotedPart4        {cons("StringEscape4")}
+    <StringQuotedChars4-LEX>                            -> StringQuotedPart4        {cons("QStr")}
+    <Dollar4-LEX>                                       -> StringQuotedPart4        {cons("QDollar")}
+    "$" <QuotedBracket4-LEX> "$"                        -> StringQuotedPart4        {cons("QBr")}
+    ~[\<\>\$]+                                          -> <StringQuotedChars4-LEX> 
+    [\<\>]                                              -> <QuotedBracket4-LEX>     
+    "$"                                                 -> <Dollar4-LEX>            
+    <Padding-LEX>                                       -> Padding                  
+                                                        -> <Padding-LEX>            {indentpadding}
+
+  lexical restrictions
+    StringQuotedChars1 -/- ~[\[\]\$]
+    StringQuotedChars2 -/- ~[\{\}\$]
+    StringQuotedChars3 -/- ~[\(\)\$]
+    StringQuotedChars4 -/- ~[\<\>\$]
+    Dollar1 -/- [\[\]] . [\$]
+    Dollar2 -/- [\{\}] . [\$]
+    Dollar3 -/- [\(\)] . [\$]
+    Dollar4 -/- [\<\>] . [\$]

--- a/Xtext/nabl/src-gen/syntax/terms/Terms.sdf
+++ b/Xtext/nabl/src-gen/syntax/terms/Terms.sdf
@@ -1,0 +1,38 @@
+module terms/Terms
+imports terms/Constants common/Identifiers terms/Vars
+
+exports
+  sorts Pattern
+
+  context-free syntax
+    Var                                -> Pattern 
+    Int                                -> Pattern {cons("Int")}
+    Real                               -> Pattern {cons("Real")}
+    String                             -> Pattern {cons("Str")}
+    Id "(" {Pattern ","}* ")"          -> Pattern {cons("Op")}
+    String "(" {Pattern ","}* ")"      -> Pattern {cons("OpQ")}
+    Char                               -> Pattern {cons("Char")}
+    "(" {Pattern ","}* ")"             -> Pattern {cons("Tuple")}
+    "[" {Pattern ","}* "]"             -> Pattern {cons("List")}
+    "[" {Pattern ","}* "|" Pattern "]" -> Pattern {cons("ListTail")}
+    Var "@" Pattern                    -> Pattern {cons("As")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Pattern {cons("COMPLETION-Pattern")}
+
+  sorts Term
+
+  context-free syntax
+    VarRef                       -> Term 
+    Int                          -> Term {cons("Int")}
+    Real                         -> Term {cons("Real")}
+    String                       -> Term {cons("Str")}
+    Id "(" {Term ","}* ")"       -> Term {cons("Op")}
+    String "(" {Term ","}* ")"   -> Term {cons("OpQ")}
+    Char                         -> Term {cons("Char")}
+    "(" {Term ","}* ")"          -> Term {cons("Tuple")}
+    "[" {Term ","}* "]"          -> Term {cons("List")}
+    "[" {Term ","}* "|" Term "]" -> Term {cons("ListTail")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Term {cons("COMPLETION-Term")}

--- a/Xtext/nabl/src-gen/syntax/terms/Vars.sdf
+++ b/Xtext/nabl/src-gen/syntax/terms/Vars.sdf
@@ -1,0 +1,19 @@
+module terms/Vars
+imports common/Identifiers terms/Terms
+
+exports
+  sorts Wld Var VarRef
+
+  context-free syntax
+    "_" -> Wld    {cons("Wld")}
+    Wld -> Var    
+    Id  -> Var    {cons("Var")}
+    LId -> Var    {cons("ListVar")}
+    Id  -> VarRef {cons("VarRef")}
+    LId -> VarRef {cons("ListVarRef")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> Wld {cons("COMPLETION-Wld")}
+
+  context-free restrictions
+    Wld -/- [a-zA-Z0-9\'\-\_]

--- a/Xtext/rename.sh
+++ b/Xtext/rename.sh
@@ -1,4 +1,7 @@
-cd sdf
+SCRIPTPATH=$(pwd -P)
+
+# First, we rename stuff for SDF
+cd $SCRIPTPATH/sdf
 
 # We need to repair relative paths
 find . -type f -print0 | xargs -0 sed -i '' 's/src-gen/sdf\/src-gen/g'
@@ -6,3 +9,13 @@ find . -type f -print0 | xargs -0 sed -i '' 's/src-gen/sdf\/src-gen/g'
 # We need to prevent name clashes, so rename prettyprint-Grammar to prettyprint-sdf-Grammar (and the same for '..-Module').
 find . -type f -print0 | xargs -0 sed -i '' 's/prettyprint-Grammar/prettyprint-sdf-Grammar/g'
 find . -type f -print0 | xargs -0 sed -i '' 's/prettyprint-Module/prettyprint-sdf-Module/g'
+
+# Then, we rename stuff for NaBL
+cd $SCRIPTPATH/nabl
+
+# We need to repair relative paths
+find . -type f -print0 | xargs -0 sed -i '' 's/src-gen/nabl\/src-gen/g'
+
+# We need to prevent name clashes, so rename prettyprint-Grammar to prettyprint-nabl-Grammar (and the same for '..-Module').
+find . -type f -print0 | xargs -0 sed -i '' 's/prettyprint-Grammar/prettyprint-nabl-Grammar/g'
+find . -type f -print0 | xargs -0 sed -i '' 's/prettyprint-Module/prettyprint-nabl-Module/g'

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -10,8 +10,8 @@ imports
 	sdf/src-gen/pp/modules/Modules-pp
 	include/Xtext
 	generate/common
+	generate/nabl
 	generate/terminal-rule
-	include/TemplateLang
 
 rules 
 	

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -137,10 +137,16 @@ rules
 		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
 	
 	gen-assignable-terminal(|name, attr):
-		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
-		
-	gen-assignable-terminal(|name, attr):
-		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
+		CrossReference(TypeRef(_, type-name), terminal-rule) -> (Sort(sort-name), [SdfProductionWithCons(SortCons(SortDef(sort-name), Constructor(sort-name)), Rhs([Sort(sort-rhs)]), attr)])
+		where
+			sort-name := <conc-strings> (type-name, "Ref");
+			sort-rhs  := <gen-assignable-terminal-name> terminal-rule
+	
+	gen-assignable-terminal-name:
+		None() -> "ID"
+	
+	gen-assignable-terminal-name:
+		Some(CrossReferenceableTerminal(RuleCall(rulecall-name))) -> rulecall-name
 	
 	gen-assignable-terminal(|name, attr):
 		AssignableAlternatives(alternatives) -> (output, nested)

--- a/Xtext/trans/generate/nabl.str
+++ b/Xtext/trans/generate/nabl.str
@@ -1,0 +1,68 @@
+// Rules to generate an nabl file for the given Xtext grammar
+
+module nabl
+
+imports
+	libstratego-gpp
+	include/NameBindingLanguage
+	nabl/src-gen/pp/NameBindingLanguage-pp
+	nabl/src-gen/pp/core/Modules-pp
+	include/Xtext
+
+rules
+	
+	nab-pp = (prettyprint-nabl-Module); !V([], <id>); box2text-string(|120)
+
+	gen-nab-debug:
+		ast -> Module("Dummy", [
+			Namespaces(namespace-defs),
+			Bindings(<conc> (def-clause, ref-clause))
+		])
+		where
+			namespace-defs := <collect(gen-nab-namespace-defs)> ast;
+			def-clause     := <collect(gen-nab-def-clause)> ast;
+			ref-clause     := <collect(gen-nab-ref-clause)> ast
+	
+	gen-nab-namespace-defs:
+		CrossReference(TypeRef(_, name), _) -> NamespaceDef(name)
+	
+	// TODO: Lookup the signature for the constructor with name <name>
+	gen-nab-def-clause:
+		CrossReference(TypeRef(_, name), _) -> BindingRule(
+          Op(name, [Var("n")])
+        , NoWhere()
+        , [ DefClause(
+              Explicit()
+            , Unique()
+            , NamespaceRef(CurrentLanguage(), name)
+            , VarRef("n")
+            , []
+            , Current()
+            , NoWhere()
+            )
+          ]
+        )
+	
+	// TODO: Lookup the signature for the constructor with name <name>
+	gen-nab-ref-clause:
+		CrossReference(TypeRef(_, name), _) -> BindingRule(
+          Op(<conc-strings> (name, "Ref"), [Var("n")])
+        , NoWhere()
+        , [ RefClause(
+              [ RefClausePart(
+                  All()
+                , NamespaceRef(CurrentLanguage(), name)
+                , VarRef("n")
+                , []
+                , Current()
+                , NoWhere()
+                )
+              ]
+            )
+          ]
+        )
+	
+	gen-nabl:
+		(selected, position, ast, path, project-path) -> (filename, <nab-pp> <gen-nab-debug> selected)
+		where
+			filename := $[[<remove-extension> path].nab]


### PR DESCRIPTION
**Work in progress, don't merge yet..**

This PR will add the creation of an NaBL file to the Xtext -> SDF transformation process. Xtext CrossReferences will be transformed into NaBL defines/refers. Given the following Xtext rule:

```
Class:
  'class' name=ID 'extends' parent=[Class|ID]
;
```

the resulting SDF and NaBL code should look as follows (note the addition of ClassRef production, which is needed to introduce the ClassRef constructor in the AST):

```
(SDF)
Class.Class = "class" name:ID "extends" parent:ClassRef
ClassRef.ClassRef = ID

(NaBL)
Class(n, _) defines Class n
ClassRef(n) refers to Class n
```

such that eventually the following code:

```
class Foo extends Foo
```

would give the following AST:

```
Class("foo", ClassRef("foo"))
```

in which name resolution works as expected.

---
- [x] Add NaBL to project
- [x] Generate .nab file with namespace for each CrossReference
- [x] Adapt transformation to output xxxRef() at use site
- [ ] Use correct constructor (lookup signature). The Xtext feature 'name' should be the definition site.
