### PR TITLE
Optional

### DIFF
--- a/Xtext-tests/Constructors/Alternatives/Alternatives.xtext
+++ b/Xtext-tests/Constructors/Alternatives/Alternatives.xtext
@@ -1,0 +1,84 @@
+/* This grammar works as intended, except for the pretty printed version of the QualifiedName, which should be transformed into one of
+the more complex list definitions. */
+
+/* This grammar will lead to a SDF3 grammar that produces an empty AST, as it would inside Xtext. The only noticeable difference is the 
+'.*' which inside an Xtext grammar can have a cardinality (as in this example), but in SDF3 only Sorts can have a cardinality, so the 
+Keyword '.*' had to be extracted to a new rule */
+
+grammar org.xtext.example.NA.No_Assignment with org.eclipse.xtext.common.Terminals
+
+generate domainmodel "http://www.xtext.org/example/domainmodel/Domainmodel"
+
+A:
+	"a" | "b"	
+;
+ 
+B:
+	"a" | "b" | "c"
+;
+ 
+C:
+	"a" | "b" | A
+;
+ 
+D:
+	a="a" | "b"
+;
+ 
+E:
+	"a" | b="b"
+;
+ 
+F:
+	a="a" | b="b"
+;
+ 
+G: 
+	("a" | "b")
+; 
+  
+H: 
+	(a="a" | b="b")
+; 
+  
+I:
+	{a} "a" | "b"	
+;
+ 
+J:
+	{a} ("a" | "b")
+;
+ 
+K:
+	({a} a="a"| {b} b="b")
+;
+ 
+L:
+	({a} a="a"| b="b")	
+;
+ 
+//More complex examples
+
+AA:
+	("a" | ("b" | "c"))	
+; 
+  
+AB:
+	a=("a" | ("b" | "c"))
+;   
+    
+AC:
+	{a} ("a" | ("b" | "c"))	
+;
+ 
+AD:
+	({a} "a" | {alt} ("b" | "c"))		
+;
+ 
+AE:
+	({a} "a" | ({b} "b" | {c} "c"))		
+;
+ 
+AF:
+	((({a} id=AE)) | {alt} ( "b" | "c"))	
+;

--- a/Xtext-tests/Constructors/Alternatives/Alternatives_Expected.sdf3
+++ b/Xtext-tests/Constructors/Alternatives/Alternatives_Expected.sdf3
@@ -1,0 +1,82 @@
+module Alternatives_Expected
+
+imports
+  
+  Terminals
+
+context-free syntax
+
+A = "a"
+A = "b"
+
+B = "a"
+B = "b"
+B = "c"
+
+C = "a"
+C = "b"
+C = A
+
+D.D1 = a:"a"
+D = "b"
+
+E = "a"
+E.E1 = b:"b"
+
+F.F1 = a:"a"
+F.F2 = b:"b"
+
+G = SubRule-1
+SubRule-1 = "a"
+SubRule-1 = "b"
+
+H = SubRule-1
+SubRule-1.SubRule-1-1 = a:"a"
+SubRule-1.SubRule-1-2 = b:"b"
+
+I.a = "a"
+I = "b"
+
+J.a = SubRule-1
+SubRule-1 = "a"
+SubRule-1 = "b"
+
+K = SubRule-1
+SubRule-1.a = a:"a"
+SubRule-1.b = b:"b"
+
+L = SubRule-1
+SubRule-1.a = a:"a"
+SubRule-1.SubRule-1-1 = b:"b"
+
+AA = SubRule-1
+SubRule-1 = "a"
+SubRule-1 = SubRule-1-1
+SubRule-1-1 = "b"
+SubRule-1-1 = "c"
+
+AB.AB-0 = a:SubRule-1
+SubRule-1 = "a"
+SubRule-1 = SubRule-1-1
+SubRule-1-1 = "b"
+SubRule-1-1 = "c"
+
+AC.a = SubRule-1
+SubRule-1 = "a"
+SubRule-1 = SubRule-1-1
+SubRule-1-1 = "b"
+SubRule-1-1 = "c"
+
+AD = SubRule-1
+SubRule-1.a = "a"
+SubRule-1.alt = SubRule-1-1
+SubRule-1-1 = "b"
+SubRule-1-1 = "c"
+
+AE = SubRule-1
+SubRule-1.a = "a"
+SubRule-1 = SubRule-1-1
+SubRule-1-1.b = "b"
+SubRule-1-1.c = "c"
+
+//ID is imported from the Terminals file, which should also be converted

--- a/Xtext-tests/Constructors/No Assignment/No_Assignment.xtext
+++ b/Xtext-tests/Constructors/No Assignment/No_Assignment.xtext
@@ -1,0 +1,34 @@
+/* This grammar works as intended, except for the pretty printed version of the QualifiedName, which should be transformed into one of
+the more complex list definitions. */
+
+/* This grammar will lead to a SDF3 grammar that produces an empty AST, as it would inside Xtext. The only noticeable difference is the 
+'.*' which inside an Xtext grammar can have a cardinality (as in this example), but in SDF3 only Sorts can have a cardinality, so the 
+Keyword '.*' had to be extracted to a new rule */
+
+grammar org.xtext.example.NA.No_Assignment with org.eclipse.xtext.common.Terminals
+
+generate domainmodel "http://www.xtext.org/example/domainmodel/Domainmodel"
+
+AbstractElement:
+	Import
+;
+
+Import:
+	'import' QualifiedNameWithWildcard
+;
+
+QualifiedNameWithWildcard:
+	QualifiedName '.*'?
+;
+
+QualifiedName:
+	ID('.' ID)*
+;
+ 
+Permutations:
+	Import & 'a'
+;
+
+Alternatives:
+	Import | 'a'	
+;

--- a/Xtext-tests/Constructors/No Assignment/No_Assignment_Expected.sdf3
+++ b/Xtext-tests/Constructors/No Assignment/No_Assignment_Expected.sdf3
@@ -1,0 +1,20 @@
+module No_Assignment_Expected
+
+imports
+  
+  Terminals
+
+context-free syntax
+
+AbstractElement = Import
+Import = 'import' QualifiedNameWithWildcard
+QualifiedNameWithWildcard = QualifiedName Keyword1?
+Keyword1 = '.*'
+QualifiedName = ID Rule1*
+Rule1 = '.' ID
+Permutations.Permutations0 = Import 'a'
+Permutations.Permutations1 = 'a' Import
+Alternatives = Import
+Alternatives = 'a'
+
+//ID is imported from the Terminals file, which should also be converted

--- a/Xtext-tests/Constructors/Simple Assignment/Case 1/Simple_Assignment.xtext
+++ b/Xtext-tests/Constructors/Simple Assignment/Case 1/Simple_Assignment.xtext
@@ -1,0 +1,23 @@
+grammar org.xtext.example.SA.Simple_Assignment with org.eclipse.xtext.common.Terminals
+
+generate domainmodel "http://www.xtext.org/example/domainmodel/Domainmodel"
+
+DomainModel:
+	model = AbstractElement
+;
+
+AbstractElement:
+	Import
+;
+
+Import:
+	'import' QualifiedNameWithWildcard
+;
+
+QualifiedNameWithWildcard:
+	QualifiedName '.*'?
+;
+
+QualifiedName:
+	ID('.' ID)*
+;

--- a/Xtext-tests/Constructors/Simple Assignment/Case 1/Simple_Assignment_Expected.sdf3
+++ b/Xtext-tests/Constructors/Simple Assignment/Case 1/Simple_Assignment_Expected.sdf3
@@ -1,0 +1,17 @@
+module Simple_Assignment_Expected
+
+imports
+  
+  Terminals
+
+context-free syntax
+
+DomainModel.DomainModel0 = model:AbstractElement
+AbstractElement = Import
+Import = 'import' QualifiedNameWithWildcard
+QualifiedNameWithWildcard = QualifiedName Keyword1?
+Keyword1 = '.*'
+QualifiedName = ID Rule1*
+Rule1 = '.' ID
+
+//ID is imported from the Terminals file, which should also be converted

--- a/Xtext-tests/Constructors/Simple Assignment/Case 2/Simple_Assignment2.xtext
+++ b/Xtext-tests/Constructors/Simple Assignment/Case 2/Simple_Assignment2.xtext
@@ -1,0 +1,27 @@
+grammar org.xtext.example.SA.Simple_Assignment2 with org.eclipse.xtext.common.Terminals
+
+generate domainmodel "http://www.xtext.org/example/domainmodel/Domainmodel"
+
+DomainModel:
+	model = AbstractElement
+;
+
+AbstractElement:
+	Import | pd=PackageDeclaration
+;
+
+Import:
+	'import' QualifiedNameWithWildcard
+;
+
+QualifiedNameWithWildcard:
+	QualifiedName '.*'?
+;
+
+QualifiedName:
+	ID('.' ID)*
+;
+ 
+ PackageDeclaration:
+ 	p='package'	
+ ;

--- a/Xtext-tests/Constructors/Simple Assignment/Case 2/Simple_Assignment2_Expected.sdf3
+++ b/Xtext-tests/Constructors/Simple Assignment/Case 2/Simple_Assignment2_Expected.sdf3
@@ -1,0 +1,18 @@
+module Simple_Assignment2_Expected
+
+imports
+  
+  Terminals
+
+context-free syntax
+
+DomainModel.DomainModel0 = model:AbstractElement
+AbstractElement = Import
+AbstractElement.AbstractElement0 = pd:PackageDeclaration
+Import = 'import' QualifiedNameWithWildcard
+QualifiedNameWithWildcard = QualifiedName Keyword1?
+Keyword1 = '.*'
+QualifiedName = ID Rule1*
+Rule1 = '.' ID
+PackageDeclaration.PackageDeclaration0 = p:'package'
+//ID is imported from the Terminals file, which should also be converted

--- a/Xtext/editor/Xtext-Menus.esv
+++ b/Xtext/editor/Xtext-Menus.esv
@@ -33,5 +33,6 @@ menus
   menu: "Generation"                   (openeditor) (realtime)
 
     action: "Generate Xtext"         = gen-xtext
+    action: "Generate Xtext > SDF"   = gen-xtext-sdf
     action: "Generate SDF (ATerm)"   = gen-sdf
 	action: "Generate SDF"           = gen-sdf-file

--- a/Xtext/editor/Xtext-Menus.esv
+++ b/Xtext/editor/Xtext-Menus.esv
@@ -31,6 +31,7 @@ menus
     end
   
   menu: "Generation"                   (openeditor) (realtime)
-    
+
+    action: "Generate Xtext"         = gen-xtext
     action: "Generate SDF (ATerm)"   = gen-sdf
 	action: "Generate SDF"           = gen-sdf-file

--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -17,8 +17,6 @@ rules
 	
 	remove-parenthetical:
 		Parenthetical(content) -> content
-		where
-			<debug> content
 			
 	// Cardinality
 	

--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -19,6 +19,7 @@ rules
 		Parenthetical(content) -> content
 		where
 			<debug> content
+			
 	// Cardinality
 	
 	gen-cardinality(|abstract-terminal):
@@ -91,7 +92,7 @@ rules
 	recursive-permutations(|set, block, n):
 		_ -> <if(<eq> (1,n), <filter-permutations(|block)> set, recursive-permutations(|new_set, block, <dec> n))>
 		where
-			new_set := <map(flatten-list)> <list-combinations> [set, block]
+			new_set := <list-combinations> [set, block]
 			
 	filter-permutations(|block):
 		set -> filtered-permutations

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -32,35 +32,54 @@ rules
 			<is-list> selected
 	
 	gen-xtext:
-		(selected, position, ast, path, project-path) -> (filename, <gen-xtext> selected)
+		(selected, _, _, path, _) -> (filename, <x> selected)
 		where
-			filename := $[[<remove-extension> path].xtextng]
+			filename := <guarantee-extension(|"xtextng")> path
 	
-	gen-xtext:
-		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
-		where
-			unordered-groups := <collect-one(is-double-alt)> alternatives
+	x:
+		x -> <innermost(expand-optional) ; flatten-parser-rules> x
+	
+	flatten-parser-rules:
+		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
+	
+	flatten-parser-rules =
+		flatten-list <+ id
+	
+	expand-optional:
+		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
+			<oncetd(remove(|abstract-terminal-token))> p,
+			<oncetd(mandatory(|abstract-terminal-token))> p
+		]
+	where
+		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
+	
+	is-abstract-terminal-token =
+		?AbstractTerminalAbstractToken(_, Some(Optional()))
+	
+	// Remove the given abstract-terminal-token from a Group of AbstractTerminalTokens
+	remove(|abstract-terminal-token):
+		Group(abstract-terminal-tokens) -> Group(removed-abstract-terminal-tokens)
+	where
+		removed-abstract-terminal-tokens := <map(?abstract-terminal-token ; ![] <+ id) ; flatten-list> abstract-terminal-tokens
+	
+	// TODO: Why is abstract-terminal-token not used here?
+	mandatory(|abstract-terminal-token):
+		AbstractTerminalAbstractToken(x, Some(Optional())) -> AbstractTerminalAbstractToken(x, None())
 	
 	// gen-xtext:
-	// 	AbstractTerminalAbstractToken(token, Some(Any())) -> y
+	// 	p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
 	// 	where
-	// 		y :=
-		
-	insert(|p):
-		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
-	
-	replace(|u):
-		Alternatives(unordered-groups) -> Alternatives(u)
-		where
-			<gt> (<length> unordered-groups, 1)
-	
-	is-double-alt:
-		Alternatives(unordered-groups) -> unordered-groups
-		where
-			<gt> (<length> unordered-groups, 1)
-		
-
-
-
-
-
+	// 		unordered-groups := <collect-one(is-double-alt)> alternatives
+	// 
+	// insert(|p):
+	// 	u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
+	// 
+	// replace(|u):
+	// 	Alternatives(unordered-groups) -> Alternatives(u)
+	// 	where
+	// 		<gt> (<length> unordered-groups, 1)
+	// 
+	// is-double-alt:
+	// 	Alternatives(unordered-groups) -> unordered-groups
+	// 	where
+	// 		<gt> (<length> unordered-groups, 1)

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -9,7 +9,7 @@ imports
 	include/Xtext
 	generate/post
 	generate/xtext-expand-optional
-	generate/xtext-expand-alternatives
+	generate/xtext-expand-alternative
 	
 rules
 	
@@ -26,14 +26,28 @@ rules
 			filename := $[[<remove-extension> path].sdf3.aterm]
 	
 	gen-sdf-debug:
-		selected -> <(gen-grammar + gen-rule) ; post> selected
+		selected -> <(gen-grammar + gen-rule) ; try(post)> selected
 	
 	gen-sdf-debug:
 		selected -> <map(gen-sdf-debug)> selected
 		where
 			<is-list> selected
 	
+	// Menu
+	gen-xtext-sdf:
+		(selected, position, ast, path, project-path) -> (filename, <gen-xtext ; gen-sdf-debug ; sdf-pp> selected)
+		where
+			filename := $[[<remove-extension> path].sdf3]
+	
+	// Menu
 	gen-xtext:
-		(selected, _, _, path, _) -> (filename, <innermost(expand-optional) ; flatten-parser-rules ; innermost(expand-alternatives)> selected)
+		(selected, _, _, path, _) -> (filename, <gen-xtext> selected)
 		where
 			filename := <guarantee-extension(|"xtextng")> path
+	
+	// Desugar selection. Do a flatten-list over the whole tree afterwards to prevent nested parser rules directly in a Grammar()
+	gen-xtext:
+		ast -> <desugar ; topdown(try(flatten-list))> ast
+	
+	// Expand optionals, then recursively desugar those expanded optionals, and finally flatten the result
+	desugar = topdown(try(expand ; desugar ; flatten-list))

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -8,6 +8,8 @@ imports
 	generate/parser-rule
 	include/Xtext
 	generate/post
+	generate/xtext-expand-optional
+	generate/xtext-expand-alternatives
 	
 rules
 	
@@ -32,54 +34,6 @@ rules
 			<is-list> selected
 	
 	gen-xtext:
-		(selected, _, _, path, _) -> (filename, <x> selected)
+		(selected, _, _, path, _) -> (filename, <innermost(expand-optional) ; flatten-parser-rules ; innermost(expand-alternatives)> selected)
 		where
 			filename := <guarantee-extension(|"xtextng")> path
-	
-	x:
-		x -> <innermost(expand-optional) ; flatten-parser-rules> x
-	
-	flatten-parser-rules:
-		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
-	
-	flatten-parser-rules =
-		flatten-list <+ id
-	
-	expand-optional:
-		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
-			<oncetd(remove(|abstract-terminal-token))> p,
-			<oncetd(mandatory(|abstract-terminal-token))> p
-		]
-	where
-		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
-	
-	is-abstract-terminal-token =
-		?AbstractTerminalAbstractToken(_, Some(Optional()))
-	
-	// Remove the given abstract-terminal-token from a Group of AbstractTerminalTokens
-	remove(|abstract-terminal-token):
-		Group(abstract-terminal-tokens) -> Group(removed-abstract-terminal-tokens)
-	where
-		removed-abstract-terminal-tokens := <map(?abstract-terminal-token ; ![] <+ id) ; flatten-list> abstract-terminal-tokens
-	
-	// TODO: Why is abstract-terminal-token not used here?
-	mandatory(|abstract-terminal-token):
-		AbstractTerminalAbstractToken(x, Some(Optional())) -> AbstractTerminalAbstractToken(x, None())
-	
-	// gen-xtext:
-	// 	p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
-	// 	where
-	// 		unordered-groups := <collect-one(is-double-alt)> alternatives
-	// 
-	// insert(|p):
-	// 	u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
-	// 
-	// replace(|u):
-	// 	Alternatives(unordered-groups) -> Alternatives(u)
-	// 	where
-	// 		<gt> (<length> unordered-groups, 1)
-	// 
-	// is-double-alt:
-	// 	Alternatives(unordered-groups) -> unordered-groups
-	// 	where
-	// 		<gt> (<length> unordered-groups, 1)

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -7,6 +7,7 @@ imports
 	sdf/src-gen/pp/modules/Modules-pp
 	generate/parser-rule
 	include/Xtext
+	generate/post
 	
 rules
 	
@@ -23,7 +24,7 @@ rules
 			filename := $[[<remove-extension> path].sdf3.aterm]
 	
 	gen-sdf-debug:
-		selected -> <gen-grammar + gen-rule> selected
+		selected -> <(gen-grammar + gen-rule) ; post> selected
 	
 	gen-sdf-debug:
 		selected -> <map(gen-sdf-debug)> selected

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -1,234 +1,65 @@
 module generate
 
-// imports
-// 	
-// 	libstratego-gpp
-// 	lib/runtime/editor/interop
-// 	lib/runtime/tmpl/pp
-// 	include/TemplateLang
-// 	sdf/src-gen/pp/TemplateLang-pp
-// 	sdf/src-gen/pp/modules/Modules-pp
-// 	include/Xtext
-// 	generate/common
-// 	generate/terminal-rule
-// 	include/TemplateLang
-// 
-// rules 
-// 	
-// 	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
-// 	
-// 	gen-sdf-file:
-// 		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
-// 		where
-// 			filename := $[[<remove-extension> path].sdf3]
-// 	
-// 	gen-sdf:
-// 		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
-// 		where
-// 			filename := $[[<remove-extension> path].sdf3.aterm]
-// 	
-// 	gen-sdf-debug:
-// 		selected -> <gen-grammar + gen-rule + gen-abstract-token> selected
-// 	
-// 	gen-sdf-debug:
-// 		selected -> <map(gen-sdf-debug)> selected
-// 		where
-// 			<is-list> selected
-// 	
-// 	gen-grammar:
-// 		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)
-// 		//$[module [name] [gen-mixin] context-free syntax [gen-abstract-rules]]
-// 		where
-// 			name               := <id-to-name> names;
-// 			imports			   := <gen-imports> mixin;
-// 			sdf-sections	   := <map(gen-rule)> abstract-rules
-// 			//gen-mixin		   := <gen-imports> mixin;
-// 			//gen-abstract-rules := <map(gen-rule) ; separate-by(|"\n")> abstract-rules
-// 		
-// 	gen-imports:
-// 		None() -> []
-// 		
-// 	gen-imports:
-// 		Some(Mixin(imports)) -> [Imports(<map(gen-import-name)> imports)]
-// 		//$[imports [<map(gen-import-name) ; separate-by(|"\n")> imports]]
-// 		
-// 	gen-import-name:
-// 		GrammarID(names) -> Module(name)
-// 		where
-// 			name			:= <id-to-name> names
-// 
-// 	gen-rule:
-// 		ParserRule(name, _,_, alternatives) -> SDFSection(ContextFreeSyntax(alts))
-// 		where
-// 			alts			:= <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
-// 		
-// 	gen-alternatives(|name, attr):
-// 		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-groups(|name, attr))> unordered-groups
-// 			
-// 	gen-unordered-groups(|name, attr):
-// 		UnorderedGroup(groups) -> <flatten-list> [group | extra_rules]
-// 		where
-// 			permutations     := <gen-permutations(|groups)>;
-// 			groups_generated := <map(gen-groups(|name, attr))> permutations;
-// 			group            := <try(concat)> <map(extract-outputs)> groups_generated;
-// 			extra_rules      := <try(concat)> <map(extract-nested-outputs)> groups_generated
-// 				
-// 	gen-groups(|name, attr):
-// 		groups -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
-// 		where
-// 			rules_generated := <map(gen-group-content(|name, attr))> groups;
-// 			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
-// 			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated			
-// 	
-// 	gen-group-content(|name, attr):
-// 		Group(content) -> (output, nested_outputs)
-// 		with
-// 			<debug> <fetch-elem(is-action) + fetch-elem(is-assignment) + id> content;
-// 			content_generated := <map(gen-abstract-token(|name, attr))> content;
-// 			output := <try(concat)> <map(extract-outputs)> content_generated;
-// 			nested_outputs := <try(concat)> <map(extract-nested-outputs)> content_generated
-// 	
-// 	is-action:
-// 		ActionAbstractToken(_) -> "action"
-// 		 		
-// 	is-assignment:
-// 		AssignmentAbstractToken(_,n,_,_,_) -> n
-// 	
-// 	extract-outputs:
-// 		(output, nested_output) -> output
-// 		
-// 	extract-nested-outputs:
-// 		(output, nested_output) -> nested_output
-// 
-// 	gen-abstract-token(|name, attr):
-// 		AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> (gen-cardinality, <flatten-list> nested_output)
-// 		with
-// 			(output, nested_output) := <gen-abstract-terminal(|name, attr, cardinality-opt)> abstract-terminal;
-// 			gen-cardinality       := <gen-cardinality(|output)> cardinality-opt
-// 
-// 	gen-abstract-terminal(|name, attr, cardinality-opt):
-// 		RuleCall(input) -> (Sort(input),[])
-// 		
-// 	gen-abstract-terminal(|name, attr, cardinality-opt):
-// 		Alternatives(unordered-groups) -> (output,nested)
-// 		where
-// 			name_string := <remove-sortdef> name;
-// 			new_name := <newname> <conc-strings> (name_string, "-");
-// 			output := Sort(new_name);
-// 			nested := <try(concat)> <map(gen-unordered-groups(|SortDef(new_name), attr))> unordered-groups
-// 	
-// 	gen-abstract-terminal(|name, attr, cardinality-opt):
-// 		Keyword(word) -> output
-// 		where
-// 			output := <if(<equal(|None())> cardinality-opt, <gen-keyword-wo-cardinality(|name, attr)> Keyword(word), <gen-keyword-w-cardinality(|name, attr)> Keyword(word))>
-// 			
-// 	gen-keyword-wo-cardinality(|name, attr):
-// 		Keyword(word) -> (Lit(<double-quote> word), [])
-// 		
-// 	gen-keyword-w-cardinality(|name, attr):
-// 		Keyword(word) -> (Sort(rulename),[subrule])
-// 		where
-// 			rulename := <newname> "Keyword";
-// 			subrule := SdfProduction(SortDef(rulename), Rhs([Lit(<double-quote> word)]), attr)
-// 			
-// 	isNone:
-// 		input -> <equal(None())> input
-// 		where
-// 			<debug> input;
-// 			<debug> <equal(None)> input;
-// 			<debug> "succeeds"
-// 	// 	where
-// 	//		output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
-// 	// 		
-// 	// gen-dq-word:
-// 	// 	input -> (Lit(<double-quote> input),[])
-// 	// 	
-// 	// gen-sq-word:
-// 	// 	input -> (CiLit(<double-quote> input),[])
-// 		
-// 	gen-abstract-token(|name, attr):
-// 		AssignmentAbstractToken(_, feature, type, assignable-terminal, cardinality-opt) -> (rule, nested_output)
-// 		where
-// 			(output, nested_output) := <gen-assignable-terminal(|name, attr)> assignable-terminal;
-// 			gen-cardinality := <gen-cardinality(|output)> cardinality-opt;
-// 			rule := Label(Unquoted(feature), gen-cardinality)
-// 		
-// 	gen-assignable-terminal(|name, attr):
-// 		RuleCall(input) -> (Sort(input),[])
-// 		
-// 	gen-assignable-terminal(|name, attr):
-// 		Keyword(word) -> (Lit(<double-quote> word),[])
-// 		// where
-// 		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
-// 	
-// 	gen-assignable-terminal(|name, attr):
-// 		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
-// 		
-// 	gen-assignable-terminal(|name, attr):
-// 		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
-// 	
-// 	gen-assignable-terminal(|name, attr):
-// 		AssignableAlternatives(alternatives) -> (output, nested)
-// 		where
-// 			name_string := <remove-sortdef> name;
-// 			new_name := <newname> <conc-strings> (name_string, "-");
-// 			output := Sort(new_name);
-// 			nested := <try(concat)> <map(gen-abstract-alternative(|SortDef(new_name), attr))> alternatives
-// 	
-// 	gen-abstract-alternative(|name, attr):
-// 		input -> [SdfProduction(name, Rhs([rule]), attr) | extra_rules]
-// 		where
-// 			(rule, nested) := <gen-assignable-terminal(|name, attr)> input;		
-// 			extra_rules		:= <try(concat)> nested
-// 		
-// //Deprecated
-// 
-// 	//gen-rule:
-// 		//ParserRule(name, _, _, alternatives) -> gen-alternatives
-// 		//where
-// 			//gen-alternatives := <gen-alternatives(|name)> alternatives
-// 
-// //	gen-alternatives(|name):
-// 	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group ; add-name(|name)) ; separate-by(|"\n")> unordered-groups]]
-// 	
-// 	//add-name(|name):
-// 		//unordered-group -> $[[name] = [unordered-group]]
-// 	
-// 	//gen-unordered-group:
-// 		//UnorderedGroup(groups) -> $[[<map(gen-group) ; separate-by(|"\n")> groups]]
-// 		
-// 	//gen-group:
-// 		//Group(abstract-tokens) -> $[<[<map(gen-abstract-token) ; separate-by(|" ")> abstract-tokens]>]
-// 		
-// 	// gen-abstract-token:
-// 	// 	AssignmentAbstractToken(_, feature, AddAssignment(), assignable-terminal, cardinality-opt) -> $[<{ [gen-assignable-terminal] " " } [gen-cardinality]>]
-// 	// 	with
-// 	// 		gen-assignable-terminal := <gen-assignable-terminal> assignable-terminal;
-// 	// 		gen-cardinality			:= <gen-cardinality> cardinality-opt
-// 	
-// //	gen-abstract-token:
-// 	//	AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> $[[gen-abstract-terminal] [gen-cardinality]]
-// 	//	with
-// 	//		gen-abstract-terminal := <gen-abstract-terminal> abstract-terminal;
-// 	//		gen-cardinality       := <gen-cardinality-opt> cardinality-opt
-// 	
-// 	gen-abstract-token:
-// 		ActionAbstractToken(_) -> $[]
-// 	
-// 	//gen-abstract-terminal:
-// 		//Keyword(ID) -> $[[ID]]
-// 		
-// 	//gen-abstract-terminal:
-// 		//RuleCall(ID) -> $[[ID]]
-// 
-// 	//gen-abstract-terminal:
-// 	 //	x@Alternatives(_) -> <gen-internal-alternatives> x
-// 	
-// //	gen-internal-alternatives:
-// 	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group) ; separate-by(|"\n")> unordered-groups]]
-// 	
-// 	//gen-assignable-terminal:
-// 		//RuleCall(ID) -> $[<[ID]>]
-// 	
-// 	//gen-assignable-terminal:
-// 	//	AssignableAlternatives(assignable-terminal) -> $[] //<map(gen-assignable-terminal)> assignable-terminal
+imports
+	
+	libstratego-gpp
+	sdf/src-gen/pp/TemplateLang-pp
+	sdf/src-gen/pp/modules/Modules-pp
+	generate/parser-rule
+	include/Xtext
+	
+rules
+	
+	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
+	
+	gen-sdf-file:
+		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
+		where
+			filename := $[[<remove-extension> path].sdf3]
+	
+	gen-sdf:
+		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
+		where
+			filename := $[[<remove-extension> path].sdf3.aterm]
+	
+	gen-sdf-debug:
+		selected -> <gen-grammar + gen-rule> selected
+	
+	gen-sdf-debug:
+		selected -> <map(gen-sdf-debug)> selected
+		where
+			<is-list> selected
+	
+	gen-xtext:
+		(selected, position, ast, path, project-path) -> (filename, <gen-xtext> selected)
+		where
+			filename := $[[<remove-extension> path].xtextng]
+	
+	gen-xtext:
+		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
+		where
+			unordered-groups := <collect-one(is-double-alt)> alternatives
+	
+	// gen-xtext:
+	// 	AbstractTerminalAbstractToken(token, Some(Any())) -> y
+	// 	where
+	// 		y :=
+		
+	insert(|p):
+		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
+	
+	replace(|u):
+		Alternatives(unordered-groups) -> Alternatives(u)
+		where
+			<gt> (<length> unordered-groups, 1)
+	
+	is-double-alt:
+		Alternatives(unordered-groups) -> unordered-groups
+		where
+			<gt> (<length> unordered-groups, 1)
+		
+
+
+
+
+

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -1,209 +1,234 @@
 module generate
 
-imports
-	
-	libstratego-gpp
-	lib/runtime/editor/interop
-	lib/runtime/tmpl/pp
-	include/TemplateLang
-	sdf/src-gen/pp/TemplateLang-pp
-	sdf/src-gen/pp/modules/Modules-pp
-	include/Xtext
-	generate/common
-	generate/terminal-rule
-	include/TemplateLang
-
-rules 
-	
-	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
-	
-	gen-sdf-file:
-		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
-		where
-			filename := $[[<remove-extension> path].sdf3]
-	
-	gen-sdf:
-		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
-		where
-			filename := $[[<remove-extension> path].sdf3.aterm]
-	
-	gen-sdf-debug:
-		selected -> <gen-grammar + gen-rule + gen-abstract-token> selected
-	
-	gen-sdf-debug:
-		selected -> <map(gen-sdf-debug)> selected
-		where
-			<is-list> selected
-	
-	gen-grammar:
-		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)
-		//$[module [name] [gen-mixin] context-free syntax [gen-abstract-rules]]
-		where
-			name               := <id-to-name> names;
-			imports			   := <gen-imports> mixin;
-			sdf-sections	   := <map(gen-rule)> abstract-rules
-			//gen-mixin		   := <gen-imports> mixin;
-			//gen-abstract-rules := <map(gen-rule) ; separate-by(|"\n")> abstract-rules
-		
-	gen-imports:
-		None() -> []
-		
-	gen-imports:
-		Some(Mixin(imports)) -> [Imports(<map(gen-import-name)> imports)]
-		//$[imports [<map(gen-import-name) ; separate-by(|"\n")> imports]]
-		
-	gen-import-name:
-		GrammarID(names) -> Module(name)
-		where
-			name			:= <id-to-name> names
-
-	gen-rule:
-		ParserRule(name, _,_, alternatives) -> SDFSection(ContextFreeSyntax(alts))
-		where
-			alts			:= <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
-		
-	gen-alternatives(|name, attr):
-		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-groups(|name, attr))> unordered-groups
-			
-	gen-unordered-groups(|name, attr):
-		UnorderedGroup(groups) -> <flatten-list> [group | extra_rules]
-		where
-			permutations     := <gen-permutations(|groups)>;
-			groups_generated := <map(gen-groups(|name, attr))> permutations;
-			group            := <try(concat)> <map(extract-outputs)> groups_generated;
-			extra_rules      := <try(concat)> <map(extract-nested-outputs)> groups_generated
-				
-	gen-groups(|name, attr):
-		groups -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
-		where
-			rules_generated := <map(gen-group-content(|name, attr))> groups;
-			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
-			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated			
-	
-	gen-group-content(|name, attr):
-		Group(content) -> (output, nested_outputs)
-		with
-			content_generated := <map(gen-abstract-token(|name, attr))> content;
-			output := <try(concat)> <map(extract-outputs)> content_generated;
-			nested_outputs := <try(concat)> <map(extract-nested-outputs)> content_generated
-			
-	extract-outputs:
-		(output, nested_output) -> output
-		
-	extract-nested-outputs:
-		(output, nested_output) -> nested_output
-
-	gen-abstract-token(|name, attr):
-		AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> (gen-cardinality, <flatten-list> nested_output)
-		with
-			(output, nested_output) := <gen-abstract-terminal(|name, attr)> abstract-terminal;
-			gen-cardinality       := <gen-cardinality(|output)> cardinality-opt
-
-	gen-abstract-terminal(|name, attr):
-		RuleCall(input) -> (Sort(input),[])
-		
-	gen-abstract-terminal(|name, attr):
-		Alternatives(unordered-groups) -> (output,nested)
-		where
-			name_string := <remove-sortdef> name;
-			new_name := <newname> <conc-strings> (name_string, "-");
-			output := Sort(new_name);
-			nested := <try(concat)> <map(gen-unordered-groups(|SortDef(new_name), attr))> unordered-groups
-	
-	gen-abstract-terminal(|name, attr):
-		Keyword(word) -> (Lit(<double-quote> word),[])
-	// 	where
-	// 		output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
-	// 		
-	// gen-dq-word:
-	// 	input -> (Lit(<double-quote> input),[])
-	// 	
-	// gen-sq-word:
-	// 	input -> (CiLit(<double-quote> input),[])
-		
-	gen-abstract-token(|name, attr):
-		AssignmentAbstractToken(_, feature, type, assignable-terminal, cardinality-opt) -> (rule, nested_output)
-		where
-			(output, nested_output) := <gen-assignable-terminal(|name, attr)> assignable-terminal;
-			gen-cardinality := <gen-cardinality(|output)> cardinality-opt;
-			rule := Label(Unquoted(feature), gen-cardinality)
-		
-	gen-assignable-terminal(|name, attr):
-		RuleCall(input) -> (Sort(input),[])
-		
-	gen-assignable-terminal(|name, attr):
-		Keyword(word) -> (Lit(<double-quote> word),[])
-		// where
-		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
-	
-	gen-assignable-terminal(|name, attr):
-		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
-		
-	gen-assignable-terminal(|name, attr):
-		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
-	
-	gen-assignable-terminal(|name, attr):
-		AssignableAlternatives(alternatives) -> (output, nested)
-		where
-			name_string := <remove-sortdef> name;
-			new_name := <newname> <conc-strings> (name_string, "-");
-			output := Sort(new_name);
-			nested := <try(concat)> <map(gen-abstract-alternative(|SortDef(new_name), attr))> alternatives
-	
-	gen-abstract-alternative(|name, attr):
-		input -> [SdfProduction(name, Rhs([rule]), attr) | extra_rules]
-		where
-			(rule, nested) := <gen-assignable-terminal(|name, attr)> input;		
-			extra_rules		:= <try(concat)> nested
-		
-//Deprecated
-
-	//gen-rule:
-		//ParserRule(name, _, _, alternatives) -> gen-alternatives
-		//where
-			//gen-alternatives := <gen-alternatives(|name)> alternatives
-
-//	gen-alternatives(|name):
-	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group ; add-name(|name)) ; separate-by(|"\n")> unordered-groups]]
-	
-	//add-name(|name):
-		//unordered-group -> $[[name] = [unordered-group]]
-	
-	//gen-unordered-group:
-		//UnorderedGroup(groups) -> $[[<map(gen-group) ; separate-by(|"\n")> groups]]
-		
-	//gen-group:
-		//Group(abstract-tokens) -> $[<[<map(gen-abstract-token) ; separate-by(|" ")> abstract-tokens]>]
-		
-	// gen-abstract-token:
-	// 	AssignmentAbstractToken(_, feature, AddAssignment(), assignable-terminal, cardinality-opt) -> $[<{ [gen-assignable-terminal] " " } [gen-cardinality]>]
-	// 	with
-	// 		gen-assignable-terminal := <gen-assignable-terminal> assignable-terminal;
-	// 		gen-cardinality			:= <gen-cardinality> cardinality-opt
-	
-//	gen-abstract-token:
-	//	AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> $[[gen-abstract-terminal] [gen-cardinality]]
-	//	with
-	//		gen-abstract-terminal := <gen-abstract-terminal> abstract-terminal;
-	//		gen-cardinality       := <gen-cardinality-opt> cardinality-opt
-	
-	gen-abstract-token:
-		ActionAbstractToken(_) -> $[]
-	
-	//gen-abstract-terminal:
-		//Keyword(ID) -> $[[ID]]
-		
-	//gen-abstract-terminal:
-		//RuleCall(ID) -> $[[ID]]
-
-	//gen-abstract-terminal:
-	 //	x@Alternatives(_) -> <gen-internal-alternatives> x
-	
-//	gen-internal-alternatives:
-	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group) ; separate-by(|"\n")> unordered-groups]]
-	
-	//gen-assignable-terminal:
-		//RuleCall(ID) -> $[<[ID]>]
-	
-	//gen-assignable-terminal:
-	//	AssignableAlternatives(assignable-terminal) -> $[] //<map(gen-assignable-terminal)> assignable-terminal
+// imports
+// 	
+// 	libstratego-gpp
+// 	lib/runtime/editor/interop
+// 	lib/runtime/tmpl/pp
+// 	include/TemplateLang
+// 	sdf/src-gen/pp/TemplateLang-pp
+// 	sdf/src-gen/pp/modules/Modules-pp
+// 	include/Xtext
+// 	generate/common
+// 	generate/terminal-rule
+// 	include/TemplateLang
+// 
+// rules 
+// 	
+// 	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
+// 	
+// 	gen-sdf-file:
+// 		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
+// 		where
+// 			filename := $[[<remove-extension> path].sdf3]
+// 	
+// 	gen-sdf:
+// 		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
+// 		where
+// 			filename := $[[<remove-extension> path].sdf3.aterm]
+// 	
+// 	gen-sdf-debug:
+// 		selected -> <gen-grammar + gen-rule + gen-abstract-token> selected
+// 	
+// 	gen-sdf-debug:
+// 		selected -> <map(gen-sdf-debug)> selected
+// 		where
+// 			<is-list> selected
+// 	
+// 	gen-grammar:
+// 		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)
+// 		//$[module [name] [gen-mixin] context-free syntax [gen-abstract-rules]]
+// 		where
+// 			name               := <id-to-name> names;
+// 			imports			   := <gen-imports> mixin;
+// 			sdf-sections	   := <map(gen-rule)> abstract-rules
+// 			//gen-mixin		   := <gen-imports> mixin;
+// 			//gen-abstract-rules := <map(gen-rule) ; separate-by(|"\n")> abstract-rules
+// 		
+// 	gen-imports:
+// 		None() -> []
+// 		
+// 	gen-imports:
+// 		Some(Mixin(imports)) -> [Imports(<map(gen-import-name)> imports)]
+// 		//$[imports [<map(gen-import-name) ; separate-by(|"\n")> imports]]
+// 		
+// 	gen-import-name:
+// 		GrammarID(names) -> Module(name)
+// 		where
+// 			name			:= <id-to-name> names
+// 
+// 	gen-rule:
+// 		ParserRule(name, _,_, alternatives) -> SDFSection(ContextFreeSyntax(alts))
+// 		where
+// 			alts			:= <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
+// 		
+// 	gen-alternatives(|name, attr):
+// 		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-groups(|name, attr))> unordered-groups
+// 			
+// 	gen-unordered-groups(|name, attr):
+// 		UnorderedGroup(groups) -> <flatten-list> [group | extra_rules]
+// 		where
+// 			permutations     := <gen-permutations(|groups)>;
+// 			groups_generated := <map(gen-groups(|name, attr))> permutations;
+// 			group            := <try(concat)> <map(extract-outputs)> groups_generated;
+// 			extra_rules      := <try(concat)> <map(extract-nested-outputs)> groups_generated
+// 				
+// 	gen-groups(|name, attr):
+// 		groups -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
+// 		where
+// 			rules_generated := <map(gen-group-content(|name, attr))> groups;
+// 			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
+// 			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated			
+// 	
+// 	gen-group-content(|name, attr):
+// 		Group(content) -> (output, nested_outputs)
+// 		with
+// 			<debug> <fetch-elem(is-action) + fetch-elem(is-assignment) + id> content;
+// 			content_generated := <map(gen-abstract-token(|name, attr))> content;
+// 			output := <try(concat)> <map(extract-outputs)> content_generated;
+// 			nested_outputs := <try(concat)> <map(extract-nested-outputs)> content_generated
+// 	
+// 	is-action:
+// 		ActionAbstractToken(_) -> "action"
+// 		 		
+// 	is-assignment:
+// 		AssignmentAbstractToken(_,n,_,_,_) -> n
+// 	
+// 	extract-outputs:
+// 		(output, nested_output) -> output
+// 		
+// 	extract-nested-outputs:
+// 		(output, nested_output) -> nested_output
+// 
+// 	gen-abstract-token(|name, attr):
+// 		AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> (gen-cardinality, <flatten-list> nested_output)
+// 		with
+// 			(output, nested_output) := <gen-abstract-terminal(|name, attr, cardinality-opt)> abstract-terminal;
+// 			gen-cardinality       := <gen-cardinality(|output)> cardinality-opt
+// 
+// 	gen-abstract-terminal(|name, attr, cardinality-opt):
+// 		RuleCall(input) -> (Sort(input),[])
+// 		
+// 	gen-abstract-terminal(|name, attr, cardinality-opt):
+// 		Alternatives(unordered-groups) -> (output,nested)
+// 		where
+// 			name_string := <remove-sortdef> name;
+// 			new_name := <newname> <conc-strings> (name_string, "-");
+// 			output := Sort(new_name);
+// 			nested := <try(concat)> <map(gen-unordered-groups(|SortDef(new_name), attr))> unordered-groups
+// 	
+// 	gen-abstract-terminal(|name, attr, cardinality-opt):
+// 		Keyword(word) -> output
+// 		where
+// 			output := <if(<equal(|None())> cardinality-opt, <gen-keyword-wo-cardinality(|name, attr)> Keyword(word), <gen-keyword-w-cardinality(|name, attr)> Keyword(word))>
+// 			
+// 	gen-keyword-wo-cardinality(|name, attr):
+// 		Keyword(word) -> (Lit(<double-quote> word), [])
+// 		
+// 	gen-keyword-w-cardinality(|name, attr):
+// 		Keyword(word) -> (Sort(rulename),[subrule])
+// 		where
+// 			rulename := <newname> "Keyword";
+// 			subrule := SdfProduction(SortDef(rulename), Rhs([Lit(<double-quote> word)]), attr)
+// 			
+// 	isNone:
+// 		input -> <equal(None())> input
+// 		where
+// 			<debug> input;
+// 			<debug> <equal(None)> input;
+// 			<debug> "succeeds"
+// 	// 	where
+// 	//		output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
+// 	// 		
+// 	// gen-dq-word:
+// 	// 	input -> (Lit(<double-quote> input),[])
+// 	// 	
+// 	// gen-sq-word:
+// 	// 	input -> (CiLit(<double-quote> input),[])
+// 		
+// 	gen-abstract-token(|name, attr):
+// 		AssignmentAbstractToken(_, feature, type, assignable-terminal, cardinality-opt) -> (rule, nested_output)
+// 		where
+// 			(output, nested_output) := <gen-assignable-terminal(|name, attr)> assignable-terminal;
+// 			gen-cardinality := <gen-cardinality(|output)> cardinality-opt;
+// 			rule := Label(Unquoted(feature), gen-cardinality)
+// 		
+// 	gen-assignable-terminal(|name, attr):
+// 		RuleCall(input) -> (Sort(input),[])
+// 		
+// 	gen-assignable-terminal(|name, attr):
+// 		Keyword(word) -> (Lit(<double-quote> word),[])
+// 		// where
+// 		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
+// 	
+// 	gen-assignable-terminal(|name, attr):
+// 		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
+// 		
+// 	gen-assignable-terminal(|name, attr):
+// 		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
+// 	
+// 	gen-assignable-terminal(|name, attr):
+// 		AssignableAlternatives(alternatives) -> (output, nested)
+// 		where
+// 			name_string := <remove-sortdef> name;
+// 			new_name := <newname> <conc-strings> (name_string, "-");
+// 			output := Sort(new_name);
+// 			nested := <try(concat)> <map(gen-abstract-alternative(|SortDef(new_name), attr))> alternatives
+// 	
+// 	gen-abstract-alternative(|name, attr):
+// 		input -> [SdfProduction(name, Rhs([rule]), attr) | extra_rules]
+// 		where
+// 			(rule, nested) := <gen-assignable-terminal(|name, attr)> input;		
+// 			extra_rules		:= <try(concat)> nested
+// 		
+// //Deprecated
+// 
+// 	//gen-rule:
+// 		//ParserRule(name, _, _, alternatives) -> gen-alternatives
+// 		//where
+// 			//gen-alternatives := <gen-alternatives(|name)> alternatives
+// 
+// //	gen-alternatives(|name):
+// 	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group ; add-name(|name)) ; separate-by(|"\n")> unordered-groups]]
+// 	
+// 	//add-name(|name):
+// 		//unordered-group -> $[[name] = [unordered-group]]
+// 	
+// 	//gen-unordered-group:
+// 		//UnorderedGroup(groups) -> $[[<map(gen-group) ; separate-by(|"\n")> groups]]
+// 		
+// 	//gen-group:
+// 		//Group(abstract-tokens) -> $[<[<map(gen-abstract-token) ; separate-by(|" ")> abstract-tokens]>]
+// 		
+// 	// gen-abstract-token:
+// 	// 	AssignmentAbstractToken(_, feature, AddAssignment(), assignable-terminal, cardinality-opt) -> $[<{ [gen-assignable-terminal] " " } [gen-cardinality]>]
+// 	// 	with
+// 	// 		gen-assignable-terminal := <gen-assignable-terminal> assignable-terminal;
+// 	// 		gen-cardinality			:= <gen-cardinality> cardinality-opt
+// 	
+// //	gen-abstract-token:
+// 	//	AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> $[[gen-abstract-terminal] [gen-cardinality]]
+// 	//	with
+// 	//		gen-abstract-terminal := <gen-abstract-terminal> abstract-terminal;
+// 	//		gen-cardinality       := <gen-cardinality-opt> cardinality-opt
+// 	
+// 	gen-abstract-token:
+// 		ActionAbstractToken(_) -> $[]
+// 	
+// 	//gen-abstract-terminal:
+// 		//Keyword(ID) -> $[[ID]]
+// 		
+// 	//gen-abstract-terminal:
+// 		//RuleCall(ID) -> $[[ID]]
+// 
+// 	//gen-abstract-terminal:
+// 	 //	x@Alternatives(_) -> <gen-internal-alternatives> x
+// 	
+// //	gen-internal-alternatives:
+// 	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group) ; separate-by(|"\n")> unordered-groups]]
+// 	
+// 	//gen-assignable-terminal:
+// 		//RuleCall(ID) -> $[<[ID]>]
+// 	
+// 	//gen-assignable-terminal:
+// 	//	AssignableAlternatives(assignable-terminal) -> $[] //<map(gen-assignable-terminal)> assignable-terminal

--- a/Xtext/trans/generate/parser-rule.str
+++ b/Xtext/trans/generate/parser-rule.str
@@ -244,17 +244,17 @@ rules
 	gen-alternatives(|name, attr):
 		//Input: Alternative with listof unorderedgroups
 		//Output: List of Contextfree rules
-		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-group(|name, attr))> unordered-groups
+		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-group(|name, attr, 1))> unordered-groups
 			
-	gen-unordered-group(|name, attr):
+	gen-unordered-group(|name, attr, main):
 		//Input: UnorderedGroup with list of groups
 		//Convert input to its final form
 		//If necessary create permutations
 		//Output: One or more permutations of the rules formed by the groups
 		UnorderedGroup(groups) -> output
 		where
-			output := <if(<equal(|1)> <length> groups, <singular-group-constructor(|name, attr)> groups, <perm-group-constructor(|name, attr)> groups)>
-	
+			output := <if(<equal(|1)> <length> groups, <singular-group-constructor(|name, attr, main)> groups, <perm-group-constructor(|name, attr)> groups)>
+		
 	perm-group-constructor(|name, attr):
 		input -> <flatten-list>[rule_set | extra_rules]
 		where
@@ -274,15 +274,18 @@ rules
 	group-constructor(|name, attr):
 		input -> SdfProductionWithCons(SortCons(name, Constructor(new_constructor)), Rhs(input), attr)
 		where
-			new_constructor := <newname> <conc-strings>(<remove-sortdef> name, "-")
+			new_constructor := <newname> <conc-strings>(<remove-sortdef> name, "-Perm-")
 			
-	singular-group-constructor(|name, attr):
+	singular-group-constructor(|name, attr, main):
 		//If any of the contents is of type assignment or action, then return a constructor name
 		[Group(content)] -> rule
 		where
-			constructor := <fetch-elem(is-action) + fetch-elem(is-assignment) + id> content;
-			output := <if(<equal(|content)> constructor, <gen-sortdef-rule(|name, attr)> content, <gen-sortconstructordef-rule(|name, attr, constructor)> content)>;
+			constructor := <collect-one(is-action) + collect-one(is-assignment) + id> content;
+			output := <if(or(<equal(|content)> constructor, <equal(|0)> main) , <gen-sortdef-rule(|name, attr)> content, <gen-sortconstructordef-rule(|name, attr, constructor)> content)>;
 			rule := <flatten-list> [<try(concat)> <(extract-outputs)> output| <try(concat)> <(extract-nested-outputs)> output]
+	
+	contains(|t)= oncetd(?t)
+
 	
 	gen-sortdef-rule(|name, attr):
 		//input: [List of AbstractTokens]
@@ -343,10 +346,10 @@ rules
 		Alternatives(unordered-groups) -> (output,nested)
 		where
 			name_string := <remove-sortdef> name;
-			new_name := <newname> <conc-strings> (name_string, "-");
+			new_name := <newname> <conc-strings> (name_string, "-SubRule-");
 			//new_name := <newname> "SubRule-";
 			output := Sort(new_name);
-			nested := <try(concat)> <map(gen-unordered-group(|SortDef(new_name), attr))> unordered-groups
+			nested := <try(concat)> <map(gen-unordered-group(|SortDef(new_name), attr, 0))> unordered-groups
 			
 	/* Revised Sections */
 	gen-abstract-token-rule(|name, attr):
@@ -383,7 +386,7 @@ rules
 		AssignableAlternatives(alternatives) -> (output, nested)
 		where
 			name_string := <remove-sortdef> name;
-			new_name := <newname> <conc-strings> (name_string, "-");
+			new_name := <newname> <conc-strings> (name_string, "-SubRule-");
 			//new_name := <newname> "SubRule-";
 			output := Sort(new_name);
 			nested := <try(concat)> <map(gen-abstract-alternative(|SortDef(new_name), attr,cardinality-opt))> alternatives

--- a/Xtext/trans/generate/parser-rule.str
+++ b/Xtext/trans/generate/parser-rule.str
@@ -1,0 +1,435 @@
+module parser-rule
+
+imports
+	
+	libstratego-gpp
+	lib/runtime/editor/interop
+	lib/runtime/tmpl/pp
+	include/TemplateLang
+	sdf/src-gen/pp/TemplateLang-pp
+	sdf/src-gen/pp/modules/Modules-pp
+	include/Xtext
+	generate/common
+	generate/generate
+	generate/terminal-rule
+	include/TemplateLang
+
+rules 
+	
+// 	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
+// 	
+// 	gen-sdf-file:
+// 		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
+// 		where
+// 			filename := $[[<remove-extension> path].sdf3]
+// 	
+// 	gen-sdf:
+// 		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
+// 		where
+// 			filename := $[[<remove-extension> path].sdf3.aterm]
+// 	
+// 	gen-sdf-debug:
+// 		selected -> <gen-grammar + gen-rule + gen-abstract-token> selected
+// 	
+// 	gen-sdf-debug:
+// 		selected -> <map(gen-sdf-debug)> selected
+// 		where
+// 			<is-list> selected
+// 	
+// 	gen-grammar:
+// 		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)
+// 		//$[module [name] [gen-mixin] context-free syntax [gen-abstract-rules]]
+// 		where
+// 			name               := <id-to-name> names;
+// 			imports			   := <gen-imports> mixin;
+// 			sdf-sections	   := <map(gen-rule)> abstract-rules
+// 			//gen-mixin		   := <gen-imports> mixin;
+// 			//gen-abstract-rules := <map(gen-rule) ; separate-by(|"\n")> abstract-rules
+// 		
+// 	gen-imports:
+// 		None() -> []
+// 		
+// 	gen-imports:
+// 		Some(Mixin(imports)) -> [Imports(<map(gen-import-name)> imports)]
+// 		//$[imports [<map(gen-import-name) ; separate-by(|"\n")> imports]]
+// 		
+// 	gen-import-name:
+// 		GrammarID(names) -> Module(name)
+// 		where
+// 			name			:= <id-to-name> names
+// 
+// 	gen-rule:
+// 		ParserRule(name, _,_, alternatives) -> SDFSection(ContextFreeSyntax(alts))
+// 		where
+// 			alts			:= <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
+// 		
+// 	gen-alternatives(|name, attr):
+// 		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-groups(|name, attr))> unordered-groups
+// 			
+// 	gen-unordered-groups(|name, attr):
+// 		UnorderedGroup(groups) -> <flatten-list> [group | extra_rules]
+// 		where
+// 			permutations     := <gen-permutations(|groups)>;
+// 			groups_generated := <map(gen-groups(|name, attr))> permutations;
+// 			group            := <try(concat)> <map(extract-outputs)> groups_generated;
+// 			extra_rules      := <try(concat)> <map(extract-nested-outputs)> groups_generated
+// 				
+// 	gen-groups(|name, attr):
+// 		groups -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
+// 		where
+// 			rules_generated := <map(gen-group-content(|name, attr))> groups;
+// 			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
+// 			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated			
+// 	
+// 	gen-group-content(|name, attr):
+// 		Group(content) -> (output, nested_outputs)
+// 		with
+// 			content_generated := <map(gen-abstract-token(|name, attr))> content;
+// 			output := <try(concat)> <map(extract-outputs)> content_generated;
+// 			nested_outputs := <try(concat)> <map(extract-nested-outputs)> content_generated
+// 			
+// 	extract-outputs:
+// 		(output, nested_output) -> output
+// 		
+// 	extract-nested-outputs:
+// 		(output, nested_output) -> nested_output
+// 
+// 
+// 			
+// 	// 	where
+// 	//		output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
+// 	// 		
+// 	// gen-dq-word:
+// 	// 	input -> (Lit(<double-quote> input),[])
+// 	// 	
+// 	// gen-sq-word:
+// 	// 	input -> (CiLit(<double-quote> input),[])
+// 		
+// 	gen-abstract-token(|name, attr):
+// 		AssignmentAbstractToken(_, feature, type, assignable-terminal, cardinality-opt) -> (rule, nested_output)
+// 		where
+// 			(output, nested_output) := <gen-assignable-terminal(|name, attr)> assignable-terminal;
+// 			gen-cardinality := <gen-cardinality(|output)> cardinality-opt;
+// 			rule := Label(Unquoted(feature), gen-cardinality)
+// 		
+// 	gen-assignable-terminal(|name, attr):
+// 		RuleCall(input) -> (Sort(input),[])
+// 		
+// 	gen-assignable-terminal(|name, attr):
+// 		Keyword(word) -> (Lit(<double-quote> word),[])
+// 		// where
+// 		// 	output := <if(is-double-quoted, gen-dq-word, gen-sq-word)> word
+// 	
+// 	gen-assignable-terminal(|name, attr):
+// 		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
+// 		
+// 	gen-assignable-terminal(|name, attr):
+// 		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
+// 	
+// 	gen-assignable-terminal(|name, attr):
+// 		AssignableAlternatives(alternatives) -> (output, nested)
+// 		where
+// 			name_string := <remove-sortdef> name;
+// 			new_name := <newname> <conc-strings> (name_string, "-");
+// 			output := Sort(new_name);
+// 			nested := <try(concat)> <map(gen-abstract-alternative(|SortDef(new_name), attr))> alternatives
+// 	
+// 	gen-abstract-alternative(|name, attr):
+// 		input -> [SdfProduction(name, Rhs([rule]), attr) | extra_rules]
+// 		where
+// 			(rule, nested) := <gen-assignable-terminal(|name, attr)> input;		
+// 			extra_rules		:= <try(concat)> nested
+// 		
+// //Deprecated
+// 
+// 	//gen-rule:
+// 		//ParserRule(name, _, _, alternatives) -> gen-alternatives
+// 		//where
+// 			//gen-alternatives := <gen-alternatives(|name)> alternatives
+// 
+// //	gen-alternatives(|name):
+// 	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group ; add-name(|name)) ; separate-by(|"\n")> unordered-groups]]
+// 	
+// 	//add-name(|name):
+// 		//unordered-group -> $[[name] = [unordered-group]]
+// 	
+// 	//gen-unordered-group:
+// 		//UnorderedGroup(groups) -> $[[<map(gen-group) ; separate-by(|"\n")> groups]]
+// 		
+// 	//gen-group:
+// 		//Group(abstract-tokens) -> $[<[<map(gen-abstract-token) ; separate-by(|" ")> abstract-tokens]>]
+// 		
+// 	// gen-abstract-token:
+// 	// 	AssignmentAbstractToken(_, feature, AddAssignment(), assignable-terminal, cardinality-opt) -> $[<{ [gen-assignable-terminal] " " } [gen-cardinality]>]
+// 	// 	with
+// 	// 		gen-assignable-terminal := <gen-assignable-terminal> assignable-terminal;
+// 	// 		gen-cardinality			:= <gen-cardinality> cardinality-opt
+// 	
+// //	gen-abstract-token:
+// 	//	AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> $[[gen-abstract-terminal] [gen-cardinality]]
+// 	//	with
+// 	//		gen-abstract-terminal := <gen-abstract-terminal> abstract-terminal;
+// 	//		gen-cardinality       := <gen-cardinality-opt> cardinality-opt
+// 	
+// 	gen-abstract-token:
+// 		ActionAbstractToken(_) -> $[]
+// 	
+// 	//gen-abstract-terminal:
+// 		//Keyword(ID) -> $[[ID]]
+// 		
+// 	//gen-abstract-terminal:
+// 		//RuleCall(ID) -> $[[ID]]
+// 
+// 	//gen-abstract-terminal:
+// 	 //	x@Alternatives(_) -> <gen-internal-alternatives> x
+// 	
+// //	gen-internal-alternatives:
+// 	//	Alternatives(unordered-groups) -> $[[<map(gen-unordered-group) ; separate-by(|"\n")> unordered-groups]]
+// 	
+// 	//gen-assignable-terminal:
+// 		//RuleCall(ID) -> $[<[ID]>]
+// 	
+// 	//gen-assignable-terminal:
+// 	//	AssignableAlternatives(assignable-terminal) -> $[] //<map(gen-assignable-terminal)> assignable-terminal
+// 	
+// 	/*	
+// 	Fixed, don't change
+// 	*/
+// 	
+	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
+	
+	gen-sdf-file:
+		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
+		where
+			filename := $[[<remove-extension> path].sdf3]
+	
+	gen-sdf:
+		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
+		where
+			filename := $[[<remove-extension> path].sdf3.aterm]
+	
+	gen-sdf-debug:
+		selected -> <gen-grammar + gen-rule> selected
+	
+	gen-sdf-debug:
+		selected -> <map(gen-sdf-debug)> selected
+		where
+			<is-list> selected
+	
+	gen-grammar:
+		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)
+		where
+			name               := <id-to-name> names;
+			imports			   := <gen-imports> mixin;
+			sdf-sections	   := <map(gen-rule)> abstract-rules
+		
+	gen-imports:
+		None() -> []
+		
+	gen-imports:
+		Some(Mixin(imports)) -> [Imports(<map(gen-import-name)> imports)]
+		
+	gen-import-name:
+		GrammarID(names) -> Module(name)
+		where
+			name			:= <id-to-name> names
+
+	gen-rule:
+		ParserRule(name, _,_, alternatives) -> SDFSection(ContextFreeSyntax(alts))
+		where
+			alts			:= <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
+	
+	//Here the mess starts
+	
+	gen-alternatives(|name, attr):
+		//Input: Alternative with listof unorderedgroups
+		//Output: List of Contextfree rules
+		Alternatives(unordered-groups) -> <flatten-list> <map(gen-unordered-group(|name, attr))> unordered-groups
+			
+	gen-unordered-group(|name, attr):
+		//Input: UnorderedGroup with list of groups
+		//Convert input to its final form
+		//If necessary create permutations
+		//Output: One or more permutations of the rules formed by the groups
+		UnorderedGroup(groups) -> output
+		where
+			output := <if(<equal(|1)> <length> groups, <singular-group-constructor(|name, attr)> groups, <perm-group-constructor(|name, attr)> groups)>
+	
+	perm-group-constructor(|name, attr):
+		input -> <flatten-list>[rule_set | extra_rules]
+		where
+			rules_generated := <map(gen-group-content(|name, attr))> input;
+			rule := <map(extract-outputs)> rules_generated;
+			permutations := <map(flatten-list)> <gen-permutations(|rule)>;
+			rule_set := <map(group-constructor(|name, attr))> permutations;
+			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated
+	
+	gen-group-content(|name, attr):
+		Group(content) -> (rule, extra_rules)
+		where
+			rules_generated := <map(gen-abstract-token-rule(|name, attr))> content;
+			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
+			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated
+
+	group-constructor(|name, attr):
+		input -> SdfProductionWithCons(SortCons(name, Constructor(new_constructor)), Rhs(input), attr)
+		where
+			new_constructor := <newname> <conc-strings>(<remove-sortdef> name, "-")
+			
+	singular-group-constructor(|name, attr):
+		//If any of the contents is of type assignment or action, then return a constructor name
+		[Group(content)] -> rule
+		where
+			constructor := <fetch-elem(is-action) + fetch-elem(is-assignment) + id> content;
+			output := <if(<equal(|content)> constructor, <gen-sortdef-rule(|name, attr)> content, <gen-sortconstructordef-rule(|name, attr, constructor)> content)>;
+			rule := <flatten-list> [<try(concat)> <(extract-outputs)> output| <try(concat)> <(extract-nested-outputs)> output]
+	
+	gen-sortdef-rule(|name, attr):
+		//input: [List of AbstractTokens]
+		//output: SdfProduction with no constructor + nested rules
+		input -> (SdfProduction(name, Rhs(rule), attr), extra_rules)
+		where
+			rules_generated := <map(gen-abstract-token-rule(|name, attr))> input;
+			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
+			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated
+			
+	gen-sortconstructordef-rule(|name, attr, constructor):
+		input -> (SdfProductionWithCons(SortCons(name, Constructor(new_constructor)), Rhs(rule), attr), extra_rules)
+		where
+			new_constructor := <if(<equal(|constructor)> "AssignmentToken", <newname> <conc-strings> (<remove-sortdef> name, "-"), <id> constructor)>;
+			rules_generated := <map(gen-abstract-token-rule(|name, attr))> input;
+			rule			:= <try(concat)> <map(extract-outputs)> rules_generated;
+			extra_rules		:= <try(concat)> <map(extract-nested-outputs)> rules_generated		
+		
+	gen-abstract-token-rule(|name, attr):
+		AssignmentAbstractToken(_, feature, type, assignable-terminal, cardinality-opt) -> (rule, nested_output)
+		where
+			(output, nested_output) := <gen-assignable-terminal(|name, attr, cardinality-opt)> assignable-terminal;
+			gen-cardinality := <gen-cardinality(|output)> cardinality-opt;
+			rule := Label(Unquoted(feature), gen-cardinality)
+	
+	extract-action-ID:
+		Action(TypeRef(_, name), _) -> name
+		
+	extract-outputs:
+		(output, nested_output) -> output
+		
+	extract-nested-outputs:
+		(output, nested_output) -> nested_output
+	
+	is-action:
+		ActionAbstractToken(action) -> output
+		where
+			output := <extract-action-ID> action
+	/*		
+	is-action:
+		AbstractTerminalAbstractToken(Alternatives([UnorderedGroup([Group(content)])]), _) -> output
+		where
+			output := <fetch-elem(is-action)> content
+	*/
+		
+	is-assignment:
+		AssignmentAbstractToken(_, _, _, _, _) -> "AssignmentToken"
+	
+	/*	
+	is-assignment:
+		AbstractTerminalAbstractToken(Alternatives([UnorderedGroup([Group(content)])]), _) -> output
+		where
+			output := <fetch-elem(is-assignment)> content
+	*/	
+	
+	
+	gen-abstract-terminal(|name, attr, cardinality-opt):
+		Alternatives(unordered-groups) -> (output,nested)
+		where
+			name_string := <remove-sortdef> name;
+			new_name := <newname> <conc-strings> (name_string, "-");
+			//new_name := <newname> "SubRule-";
+			output := Sort(new_name);
+			nested := <try(concat)> <map(gen-unordered-group(|SortDef(new_name), attr))> unordered-groups
+			
+	/* Revised Sections */
+	gen-abstract-token-rule(|name, attr):
+		AbstractTerminalAbstractToken(abstract-terminal, cardinality-opt) -> (gen-cardinality, <flatten-list> nested_output)
+		with
+			(output, nested_output) := <gen-abstract-terminal(|name, attr, cardinality-opt)> abstract-terminal;
+			gen-cardinality       := <gen-cardinality(|output)> cardinality-opt
+
+
+		
+
+	
+	
+
+			
+			
+			
+			
+	gen-assignable-terminal(|name, attr, cardinality-opt):
+		RuleCall(input) -> (Sort(input),[])
+		
+	gen-assignable-terminal(|name, attr, cardinality-opt):
+		Keyword(word) -> output
+		where
+			output := <if(<equal(|None())> cardinality-opt, <gen-keyword-wo-cardinality(|name, attr)> Keyword(word), <gen-keyword-w-cardinality(|name, attr)> Keyword(word))>
+			
+	gen-assignable-terminal(|name, attr, cardinality-opt):
+		CrossReference(TypeRef(_, _), None()) -> (Sort("ID"), [])
+		
+	gen-assignable-terminal(|name, attr, cardinality-opt):
+		CrossReference(TypeRef(_, _), Some(CrossReferenceableTerminal(RuleCall(terminal-rule)))) -> (Sort(terminal-rule), [])
+	
+	gen-assignable-terminal(|name, attr, cardinality-opt):
+		AssignableAlternatives(alternatives) -> (output, nested)
+		where
+			name_string := <remove-sortdef> name;
+			new_name := <newname> <conc-strings> (name_string, "-");
+			//new_name := <newname> "SubRule-";
+			output := Sort(new_name);
+			nested := <try(concat)> <map(gen-abstract-alternative(|SortDef(new_name), attr,cardinality-opt))> alternatives
+			
+		gen-abstract-alternative(|name, attr, cardinality-opt):
+		input -> [SdfProduction(name, Rhs([rule]), attr) | extra_rules]
+		where
+			(rule, nested) := <gen-assignable-terminal(|name, attr, cardinality-opt)> input;		
+			extra_rules		:= <try(concat)> nested
+
+	//Need to fix the look of this, currently introduces extra space in final program 
+	gen-abstract-token-rule(|name, attr):
+ 		ActionAbstractToken(_) -> (Lit(""),[])
+
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 			
+ 	/* Abstract Terminal Rulecall */
+	gen-abstract-terminal(|name, attr, cardinality-opt):
+		RuleCall(input) -> (Sort(input),[])
+	
+	/* Abstract Terminal Keyword */
+	gen-abstract-terminal(|name, attr, cardinality-opt):
+		Keyword(word) -> output
+		where
+			output := <if(<equal(|None())> cardinality-opt, <gen-keyword-wo-cardinality(|name, attr)> Keyword(word), <gen-keyword-w-cardinality(|name, attr)> Keyword(word))>
+			
+	gen-keyword-wo-cardinality(|name, attr):
+		Keyword(word) -> (Lit(<double-quote> word), [])
+		
+	gen-keyword-w-cardinality(|name, attr):
+		Keyword(word) -> (Sort(rulename),[subrule])
+		where
+			rulename := <newname> "Keyword-";
+			subrule := SdfProduction(SortDef(rulename), Rhs([Lit(<double-quote> word)]), attr)

--- a/Xtext/trans/generate/parser-rule.str
+++ b/Xtext/trans/generate/parser-rule.str
@@ -12,7 +12,6 @@ imports
 	generate/common
 	generate/generate
 	generate/terminal-rule
-	include/TemplateLang
 
 rules 
 	
@@ -196,25 +195,7 @@ rules
 // 	Fixed, don't change
 // 	*/
 // 	
-	sdf-pp = (prettyprint-sdf-Module + prettyprint-sdf-Grammar + prettyprint-Section); !V([], <id>); box2text-string(|120)
-	
-	gen-sdf-file:
-		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> <gen-sdf-debug> selected)
-		where
-			filename := $[[<remove-extension> path].sdf3]
-	
-	gen-sdf:
-		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
-		where
-			filename := $[[<remove-extension> path].sdf3.aterm]
-	
-	gen-sdf-debug:
-		selected -> <gen-grammar + gen-rule> selected
-	
-	gen-sdf-debug:
-		selected -> <map(gen-sdf-debug)> selected
-		where
-			<is-list> selected
+
 	
 	gen-grammar:
 		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)

--- a/Xtext/trans/generate/post.str
+++ b/Xtext/trans/generate/post.str
@@ -1,0 +1,23 @@
+module post
+
+imports
+	
+	include/TemplateLang
+
+rules
+		
+  /**
+   * Group SdfProductions inside ContextFreeSyntax respectively
+   * LexicalSyntax together.
+   */
+  post:
+    Module(x, y, sdf-sections) -> Module(x, y, [
+      SDFSection(ContextFreeSyntax(cfs-productions)),
+      SDFSection(LexicalSyntax(lex-productions))
+    ])
+    with
+      cfs* := <collect(?ContextFreeSyntax(_))> sdf-sections;
+      cfs-productions := <collect(?SdfProduction(_, _, _))> cfs*;
+
+      lex* := <collect(?LexicalSyntax(_))> sdf-sections;
+      lex-productions := <collect(?SdfProduction(_, _, _))> lex*

--- a/Xtext/trans/generate/post.str
+++ b/Xtext/trans/generate/post.str
@@ -17,7 +17,7 @@ rules
     ])
     with
       cfs* := <collect(?ContextFreeSyntax(_))> sdf-sections;
-      cfs-productions := <collect(?SdfProduction(_, _, _))> cfs*;
+      cfs-productions := <collect(?SdfProduction(_, _, _)+?SdfProductionWithCons(_,_,_))> cfs*;
 
       lex* := <collect(?LexicalSyntax(_))> sdf-sections;
       lex-productions := <collect(?SdfProduction(_, _, _))> lex*

--- a/Xtext/trans/generate/xtext-expand-alternative.str
+++ b/Xtext/trans/generate/xtext-expand-alternative.str
@@ -1,4 +1,4 @@
-module xtext-expand-alternatives
+module xtext-expand-alternative
 
 imports
 	
@@ -6,7 +6,7 @@ imports
 	
 rules
 	
-	expand-alternatives:
+	expand:
 		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
 		where
 			unordered-groups := <collect-one(is-double-alt)> alternatives
@@ -15,7 +15,7 @@ rules
 		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
 	
 	replace(|u):
-		Alternatives(unordered-groups) -> Alternatives(u)
+		Alternatives(unordered-groups) -> Alternatives([u])
 		where
 			<gt> (<length> unordered-groups, 1)
 	

--- a/Xtext/trans/generate/xtext-expand-alternatives.str
+++ b/Xtext/trans/generate/xtext-expand-alternatives.str
@@ -1,0 +1,25 @@
+module xtext-expand-alternatives
+
+imports
+	
+	include/Xtext
+	
+rules
+	
+	expand-alternatives:
+		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
+		where
+			unordered-groups := <collect-one(is-double-alt)> alternatives
+	
+	insert(|p):
+		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
+	
+	replace(|u):
+		Alternatives(unordered-groups) -> Alternatives(u)
+		where
+			<gt> (<length> unordered-groups, 1)
+	
+	is-double-alt:
+		Alternatives(unordered-groups) -> unordered-groups
+		where
+			<gt> (<length> unordered-groups, 1)

--- a/Xtext/trans/generate/xtext-expand-optional.str
+++ b/Xtext/trans/generate/xtext-expand-optional.str
@@ -1,0 +1,34 @@
+module xtext-expand-optional
+
+imports
+	
+	include/Xtext
+	
+rules
+	
+	flatten-parser-rules:
+		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
+	
+	flatten-parser-rules =
+		flatten-list <+ id
+	
+	expand-optional:
+		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
+			<oncetd(remove(|abstract-terminal-token))> p,
+			<oncetd(mandatory(|abstract-terminal-token))> p
+		]
+	where
+		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
+	
+	is-abstract-terminal-token =
+		?AbstractTerminalAbstractToken(_, Some(Optional()))
+	
+	// Remove the given abstract-terminal-token from a Group of AbstractTerminalTokens
+	remove(|abstract-terminal-token):
+		Group(abstract-terminal-tokens) -> Group(removed-abstract-terminal-tokens)
+	where
+		removed-abstract-terminal-tokens := <map(?abstract-terminal-token ; ![] <+ id) ; flatten-list> abstract-terminal-tokens
+	
+	// TODO: Why is abstract-terminal-token not used here?
+	mandatory(|abstract-terminal-token):
+		AbstractTerminalAbstractToken(x, Some(Optional())) -> AbstractTerminalAbstractToken(x, None())

--- a/Xtext/trans/generate/xtext-expand-optional.str
+++ b/Xtext/trans/generate/xtext-expand-optional.str
@@ -6,14 +6,8 @@ imports
 	
 rules
 	
-	flatten-parser-rules:
-		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
-	
-	flatten-parser-rules =
-		flatten-list <+ id
-	
-	expand-optional:
-		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
+	expand:
+		p@ParserRule(_, _, _, alternatives) -> [
 			<oncetd(remove(|abstract-terminal-token))> p,
 			<oncetd(mandatory(|abstract-terminal-token))> p
 		]


### PR DESCRIPTION
Expand parser rules with optionals and alternatives into multiple parser rules. This will result in an Xtext that is easier to turn into SDF. This especially helps with determining constructors for certain rules.
