### PR TITLE
Optional

### DIFF
--- a/Xtext/editor/Xtext-Menus.esv
+++ b/Xtext/editor/Xtext-Menus.esv
@@ -33,5 +33,6 @@ menus
   menu: "Generation"                   (openeditor) (realtime)
 
     action: "Generate Xtext"         = gen-xtext
+    action: "Generate Xtext > SDF"   = gen-xtext-sdf
     action: "Generate SDF (ATerm)"   = gen-sdf
 	action: "Generate SDF"           = gen-sdf-file

--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -17,8 +17,6 @@ rules
 	
 	remove-parenthetical:
 		Parenthetical(content) -> content
-		where
-			<debug> content
 			
 	// Cardinality
 	

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -32,35 +32,54 @@ rules
 			<is-list> selected
 	
 	gen-xtext:
-		(selected, position, ast, path, project-path) -> (filename, <gen-xtext> selected)
+		(selected, _, _, path, _) -> (filename, <x> selected)
 		where
-			filename := $[[<remove-extension> path].xtextng]
+			filename := <guarantee-extension(|"xtextng")> path
 	
-	gen-xtext:
-		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
-		where
-			unordered-groups := <collect-one(is-double-alt)> alternatives
+	x:
+		x -> <innermost(expand-optional) ; flatten-parser-rules> x
+	
+	flatten-parser-rules:
+		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
+	
+	flatten-parser-rules =
+		flatten-list <+ id
+	
+	expand-optional:
+		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
+			<oncetd(remove(|abstract-terminal-token))> p,
+			<oncetd(mandatory(|abstract-terminal-token))> p
+		]
+	where
+		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
+	
+	is-abstract-terminal-token =
+		?AbstractTerminalAbstractToken(_, Some(Optional()))
+	
+	// Remove the given abstract-terminal-token from a Group of AbstractTerminalTokens
+	remove(|abstract-terminal-token):
+		Group(abstract-terminal-tokens) -> Group(removed-abstract-terminal-tokens)
+	where
+		removed-abstract-terminal-tokens := <map(?abstract-terminal-token ; ![] <+ id) ; flatten-list> abstract-terminal-tokens
+	
+	// TODO: Why is abstract-terminal-token not used here?
+	mandatory(|abstract-terminal-token):
+		AbstractTerminalAbstractToken(x, Some(Optional())) -> AbstractTerminalAbstractToken(x, None())
 	
 	// gen-xtext:
-	// 	AbstractTerminalAbstractToken(token, Some(Any())) -> y
+	// 	p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
 	// 	where
-	// 		y :=
-		
-	insert(|p):
-		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
-	
-	replace(|u):
-		Alternatives(unordered-groups) -> Alternatives(u)
-		where
-			<gt> (<length> unordered-groups, 1)
-	
-	is-double-alt:
-		Alternatives(unordered-groups) -> unordered-groups
-		where
-			<gt> (<length> unordered-groups, 1)
-		
-
-
-
-
-
+	// 		unordered-groups := <collect-one(is-double-alt)> alternatives
+	// 
+	// insert(|p):
+	// 	u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
+	// 
+	// replace(|u):
+	// 	Alternatives(unordered-groups) -> Alternatives(u)
+	// 	where
+	// 		<gt> (<length> unordered-groups, 1)
+	// 
+	// is-double-alt:
+	// 	Alternatives(unordered-groups) -> unordered-groups
+	// 	where
+	// 		<gt> (<length> unordered-groups, 1)

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -9,7 +9,7 @@ imports
 	include/Xtext
 	generate/post
 	generate/xtext-expand-optional
-	generate/xtext-expand-alternatives
+	generate/xtext-expand-alternative
 	
 rules
 	
@@ -26,14 +26,28 @@ rules
 			filename := $[[<remove-extension> path].sdf3.aterm]
 	
 	gen-sdf-debug:
-		selected -> <(gen-grammar + gen-rule) ; post> selected
+		selected -> <(gen-grammar + gen-rule) ; try(post)> selected
 	
 	gen-sdf-debug:
 		selected -> <map(gen-sdf-debug)> selected
 		where
 			<is-list> selected
 	
+	// Menu
+	gen-xtext-sdf:
+		(selected, position, ast, path, project-path) -> (filename, <gen-xtext ; gen-sdf-debug ; sdf-pp> selected)
+		where
+			filename := $[[<remove-extension> path].sdf3]
+	
+	// Menu
 	gen-xtext:
-		(selected, _, _, path, _) -> (filename, <innermost(expand-optional) ; flatten-parser-rules ; innermost(expand-alternatives)> selected)
+		(selected, _, _, path, _) -> (filename, <gen-xtext> selected)
 		where
 			filename := <guarantee-extension(|"xtextng")> path
+	
+	// Desugar selection. Do a flatten-list over the whole tree afterwards to prevent nested parser rules directly in a Grammar()
+	gen-xtext:
+		ast -> <desugar ; topdown(try(flatten-list))> ast
+	
+	// Expand optionals, then recursively desugar those expanded optionals, and finally flatten the result
+	desugar = topdown(try(expand ; desugar ; flatten-list))

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -8,6 +8,8 @@ imports
 	generate/parser-rule
 	include/Xtext
 	generate/post
+	generate/xtext-expand-optional
+	generate/xtext-expand-alternatives
 	
 rules
 	
@@ -32,54 +34,6 @@ rules
 			<is-list> selected
 	
 	gen-xtext:
-		(selected, _, _, path, _) -> (filename, <x> selected)
+		(selected, _, _, path, _) -> (filename, <innermost(expand-optional) ; flatten-parser-rules ; innermost(expand-alternatives)> selected)
 		where
 			filename := <guarantee-extension(|"xtextng")> path
-	
-	x:
-		x -> <innermost(expand-optional) ; flatten-parser-rules> x
-	
-	flatten-parser-rules:
-		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
-	
-	flatten-parser-rules =
-		flatten-list <+ id
-	
-	expand-optional:
-		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
-			<oncetd(remove(|abstract-terminal-token))> p,
-			<oncetd(mandatory(|abstract-terminal-token))> p
-		]
-	where
-		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
-	
-	is-abstract-terminal-token =
-		?AbstractTerminalAbstractToken(_, Some(Optional()))
-	
-	// Remove the given abstract-terminal-token from a Group of AbstractTerminalTokens
-	remove(|abstract-terminal-token):
-		Group(abstract-terminal-tokens) -> Group(removed-abstract-terminal-tokens)
-	where
-		removed-abstract-terminal-tokens := <map(?abstract-terminal-token ; ![] <+ id) ; flatten-list> abstract-terminal-tokens
-	
-	// TODO: Why is abstract-terminal-token not used here?
-	mandatory(|abstract-terminal-token):
-		AbstractTerminalAbstractToken(x, Some(Optional())) -> AbstractTerminalAbstractToken(x, None())
-	
-	// gen-xtext:
-	// 	p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
-	// 	where
-	// 		unordered-groups := <collect-one(is-double-alt)> alternatives
-	// 
-	// insert(|p):
-	// 	u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
-	// 
-	// replace(|u):
-	// 	Alternatives(unordered-groups) -> Alternatives(u)
-	// 	where
-	// 		<gt> (<length> unordered-groups, 1)
-	// 
-	// is-double-alt:
-	// 	Alternatives(unordered-groups) -> unordered-groups
-	// 	where
-	// 		<gt> (<length> unordered-groups, 1)

--- a/Xtext/trans/generate/xtext-expand-alternative.str
+++ b/Xtext/trans/generate/xtext-expand-alternative.str
@@ -1,4 +1,4 @@
-module xtext-expand-alternatives
+module xtext-expand-alternative
 
 imports
 	
@@ -6,7 +6,7 @@ imports
 	
 rules
 	
-	expand-alternatives:
+	expand:
 		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
 		where
 			unordered-groups := <collect-one(is-double-alt)> alternatives
@@ -15,7 +15,7 @@ rules
 		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
 	
 	replace(|u):
-		Alternatives(unordered-groups) -> Alternatives(u)
+		Alternatives(unordered-groups) -> Alternatives([u])
 		where
 			<gt> (<length> unordered-groups, 1)
 	

--- a/Xtext/trans/generate/xtext-expand-alternatives.str
+++ b/Xtext/trans/generate/xtext-expand-alternatives.str
@@ -1,0 +1,25 @@
+module xtext-expand-alternatives
+
+imports
+	
+	include/Xtext
+	
+rules
+	
+	expand-alternatives:
+		p@ParserRule(_, _, _, alternatives) -> <map(insert(|p))> unordered-groups
+		where
+			unordered-groups := <collect-one(is-double-alt)> alternatives
+	
+	insert(|p):
+		u@UnorderedGroup(_) -> <oncetd(replace(|u))> p
+	
+	replace(|u):
+		Alternatives(unordered-groups) -> Alternatives(u)
+		where
+			<gt> (<length> unordered-groups, 1)
+	
+	is-double-alt:
+		Alternatives(unordered-groups) -> unordered-groups
+		where
+			<gt> (<length> unordered-groups, 1)

--- a/Xtext/trans/generate/xtext-expand-optional.str
+++ b/Xtext/trans/generate/xtext-expand-optional.str
@@ -1,0 +1,34 @@
+module xtext-expand-optional
+
+imports
+	
+	include/Xtext
+	
+rules
+	
+	flatten-parser-rules:
+		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
+	
+	flatten-parser-rules =
+		flatten-list <+ id
+	
+	expand-optional:
+		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
+			<oncetd(remove(|abstract-terminal-token))> p,
+			<oncetd(mandatory(|abstract-terminal-token))> p
+		]
+	where
+		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
+	
+	is-abstract-terminal-token =
+		?AbstractTerminalAbstractToken(_, Some(Optional()))
+	
+	// Remove the given abstract-terminal-token from a Group of AbstractTerminalTokens
+	remove(|abstract-terminal-token):
+		Group(abstract-terminal-tokens) -> Group(removed-abstract-terminal-tokens)
+	where
+		removed-abstract-terminal-tokens := <map(?abstract-terminal-token ; ![] <+ id) ; flatten-list> abstract-terminal-tokens
+	
+	// TODO: Why is abstract-terminal-token not used here?
+	mandatory(|abstract-terminal-token):
+		AbstractTerminalAbstractToken(x, Some(Optional())) -> AbstractTerminalAbstractToken(x, None())

--- a/Xtext/trans/generate/xtext-expand-optional.str
+++ b/Xtext/trans/generate/xtext-expand-optional.str
@@ -6,14 +6,8 @@ imports
 	
 rules
 	
-	flatten-parser-rules:
-		Grammar(a, b, c, d, parser-rules) -> Grammar(a, b, c, d, <flatten-list> parser-rules)
-	
-	flatten-parser-rules =
-		flatten-list <+ id
-	
-	expand-optional:
-		p@ParserRule(_, _, _, alternatives) -> <flatten-list> [
+	expand:
+		p@ParserRule(_, _, _, alternatives) -> [
 			<oncetd(remove(|abstract-terminal-token))> p,
 			<oncetd(mandatory(|abstract-terminal-token))> p
 		]


### PR DESCRIPTION
Expand parser rules with optionals and alternatives into multiple parser rules. This will result in an Xtext that is easier to turn into SDF. This especially helps with determining constructors for certain rules.
