### PR TITLE
Quotes

### DIFF
--- a/Xtext/tests/keyword.str
+++ b/Xtext/tests/keyword.str
@@ -1,0 +1,28 @@
+module keyword
+
+imports
+  libstratego-lib
+  include/Xtext
+  include/TemplateLang
+  trans/generate/parser-rule
+  
+strategies
+  main =
+    test-suite(!"keyword",
+      test-single-quote;
+      test-double-quote
+    )
+
+  test-single-quote =
+    apply-test(!"turn single quotes into double quotes"
+    , gen-quoted-word
+    , !"'abc'"
+    , !Lit("\"abc\"")
+    )
+  
+  test-double-quote =
+    apply-test(!"leave double quotes"
+    , gen-quoted-word
+    , !"\"abc\""
+    , !Lit("\"abc\"")
+    )

--- a/Xtext/trans/generate/parser-rule.str
+++ b/Xtext/trans/generate/parser-rule.str
@@ -410,10 +410,10 @@ rules
 			output := <if(<equal(|None())> cardinality-opt, <gen-keyword-wo-cardinality(|name, attr)> Keyword(word), <gen-keyword-w-cardinality(|name, attr)> Keyword(word))>
 			
 	gen-keyword-wo-cardinality(|name, attr):
-		Keyword(word) -> (Lit(<double-quote> word), [])
+		Keyword(word) -> (Lit(<double-quote> <try(un-single-quote + un-double-quote)> word), [])
 		
 	gen-keyword-w-cardinality(|name, attr):
 		Keyword(word) -> (Sort(rulename),[subrule])
 		where
 			rulename := <newname> "Keyword-";
-			subrule := SdfProduction(SortDef(rulename), Rhs([Lit(<double-quote> word)]), attr)
+			subrule := SdfProduction(SortDef(rulename), Rhs([Lit(<double-quote> <try(un-single-quote + un-double-quote)> word)]), attr)

--- a/Xtext/trans/generate/parser-rule.str
+++ b/Xtext/trans/generate/parser-rule.str
@@ -410,10 +410,14 @@ rules
 			output := <if(<equal(|None())> cardinality-opt, <gen-keyword-wo-cardinality(|name, attr)> Keyword(word), <gen-keyword-w-cardinality(|name, attr)> Keyword(word))>
 			
 	gen-keyword-wo-cardinality(|name, attr):
-		Keyword(word) -> (Lit(<double-quote> <try(un-single-quote + un-double-quote)> word), [])
+		Keyword(word) -> (<gen-quoted-word> word, [])
 		
 	gen-keyword-w-cardinality(|name, attr):
 		Keyword(word) -> (Sort(rulename),[subrule])
 		where
 			rulename := <newname> "Keyword-";
-			subrule := SdfProduction(SortDef(rulename), Rhs([Lit(<double-quote> <try(un-single-quote + un-double-quote)> word)]), attr)
+			subrule := SdfProduction(SortDef(rulename), Rhs([<gen-quoted-word> word]), attr)
+  
+  gen-quoted-word:
+    word -> Lit(<double-quote> <try(un-single-quote + un-double-quote)> word)
+

--- a/Xtext/trans/generate/xtext-obtain-priorities.str
+++ b/Xtext/trans/generate/xtext-obtain-priorities.str
@@ -3,13 +3,8 @@ module xtext-obtain-priorities
 imports
 	
 	libstratego-gpp
-	lib/runtime/editor/interop
-	lib/runtime/tmpl/pp
 	include/TemplateLang
-	sdf/src-gen/pp/TemplateLang-pp
-	sdf/src-gen/pp/modules/Modules-pp
 	include/Xtext
-	generate/generate
 	
 rules
 	obtain-priorities:


### PR DESCRIPTION
Make sure that single quoted strings and double quoted strings in Xtext turn out as double quoted strings in SDF. Added tests to ensure this problem won't come back in the future.
