### PR TITLE
Undefined constructor

### DIFF
--- a/Xtext/syntax/ParserRule.sdf3
+++ b/Xtext/syntax/ParserRule.sdf3
@@ -45,14 +45,15 @@ context-free syntax
   
   AssignableTerminal.Keyword = STRING
   AssignableTerminal = RuleCall
-  AssignableTerminal = <( <AssignableAlternatives> )>
+  // {bracket} is added because without it, the constructor will not be available 
+  AssignableTerminal = <( <AssignableAlternatives> )> {bracket}
   AssignableTerminal.CrossReference = <[ <TypeRef> <CrossReferenceableTerminal?> ]> 
   
   CrossReferenceableTerminal.CrossReferenceableTerminal = <| <RuleCall>>
   
   RuleCall.RuleCall = ID
   
-  AssignableAlternatives.AssignableAlternatives = <<{AssignableTerminal "|"}+>>
+  AssignableAlternatives.AssignableAlternatives = {AssignableTerminal "|"}+
   
   Action.Action = <{ <TypeRef> <ActionCurrent?> }>
   ActionCurrent.ActionCurrent = <. <ID> <Operator> current>


### PR DESCRIPTION
Spoofax complained that the `AssignableAlternatives` constructor was not defined. As a consequence the test file did not compile. However, there seems nothing wrong with its definition:

```
AssignableAlternatives.AssignableAlternatives = {AssignableTerminal "|"}+
```

I don't know why Spoofax did not recognize the constructor, but it looks like the production without constructor was causing a problem:

```
AssignableTerminal = <( <AssignableAlternatives> )>
```

Adding `{bracket}` to this production fixed it.
