### PR TITLE
Terminal fixes

### DIFF
--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -105,6 +105,10 @@ rules
    */
   append:
     (list, e) -> <reverse> [e | <reverse> list]
+
+rules // Rewrite reserved words
+  
+  sort-name = string-as-chars(map(try(?'_'; !'-')))
   
 rules // Pattern match left- and right associative ParserRules
   

--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -14,10 +14,6 @@ rules
 	
 	remove-sortdef:
 		SortDef(name) -> name
-	
-	remove-parenthetical:
-		// Parenthetical(content) -> content
-		content -> content
 			
 	// Cardinality
 	
@@ -109,7 +105,7 @@ rules
    */
   append:
     (list, e) -> <reverse> [e | <reverse> list]
-    
+  
 rules // Pattern match left- and right associative ParserRules
   
   is-left-assoc = is-simple-left-assoc + is-nested-left-assoc

--- a/Xtext/trans/generate/terminal-rule.str
+++ b/Xtext/trans/generate/terminal-rule.str
@@ -48,7 +48,7 @@ rules
 		[head | tail] -> Alt(head, <list-to-alt> tail)
 	
 	gen-terminal-token-element:
-		Keyword(s) -> CiLit(<single-quote> s)
+		Keyword(s) -> CiLit(s)
 	
 	gen-terminal-token-element:
 		CharacterRange(Keyword(x), Keyword(y)) -> CharClass(Simple(Present(Range(Short(x), Short(y)))))

--- a/Xtext/trans/generate/terminal-rule.str
+++ b/Xtext/trans/generate/terminal-rule.str
@@ -6,6 +6,11 @@ imports
 	include/TemplateLang
 	generate/common
 
+signature
+
+  constructors
+    Parenthetical : Unknown -> Unknown
+    
 rules
 
 	list-to-conc:
@@ -15,13 +20,56 @@ rules
 		[head | tail] -> Conc(head, <list-to-conc> tail)
 	
 	gen-rule:
-		TerminalRule(Returns(terminal-name, _), terminal-token-element) ->
-			SDFSection(LexicalSyntax([SdfProduction(SortDef(terminal-name), Rhs([syntax-rules]), NoAttrs())]))
+		TerminalRule(head, alternatives) ->
+			SDFSection(LexicalSyntax([SdfProduction(SortDef(name), rhs, NoAttrs())]))
 			where
-				syntax-rules := <gen-terminal-token-element ; innermost(post-process-terminal-rule); remove-parenthetical> terminal-token-element
+				name := <gen-rule-name> head
+			; syntax-rules := <gen-terminal-token-element ; make-list> alternatives
+		  ; rhs          := <innermost(post-process-terminal-rule)> Rhs(syntax-rules)
+  
+  gen-rule-name:
+  	Fragment(name) -> name
+  
+  gen-rule-name:
+  	Returns(name, _) -> name
+  
+  /**
+   * Turn a non-list into a list or return the given list
+   */
+  make-list = is-list < id + ![<id>]
 	
-	post-process-terminal-rule:
-		CharClass(Simple(Present(Alt(x, y)))) -> Alt(x, y)
+  post-process-terminal-rule:
+    CharClass(Simple(Present(Alt(x, y)))) -> Alt(x, y)
+  
+  /**
+   * Final rule to remove outermost single parenthetical
+   */
+  post-process-terminal-rule:
+    Rhs([Parenthetical(x)]) -> Rhs([x])
+  
+  /**
+   * Remove redundant parenthesis. A CharClass already has square brackets.
+   */
+  post-process-terminal-rule:
+    Parenthetical(CharClass(x)) -> CharClass(x)
+
+  /**
+   * Remove redundant parenthesis. A Sequence already has parenthesis.
+   */
+  post-process-terminal-rule:
+    Parenthetical(Sequence(h, t)) -> Sequence(h, t)
+  
+  /**
+   * If the rhs only consists of a sequence, just make it an array (removes redundant parenthesis)
+   */
+  post-process-terminal-rule:
+    Rhs([Sequence(head, tail)]) -> Rhs([head | tail])
+  
+  /**
+   * In the post-processing, remove redundant parentheticals
+   */
+  post-process-terminal-rule:
+    Parenthetical(Parenthetical(x)) -> Parenthetical(x)
 	
 	gen-terminal-alternative:
 		TerminalGroup(terminal-group) -> gen-terminal-group
@@ -51,15 +99,27 @@ rules
 		Keyword(s) -> CiLit(s)
 	
 	gen-terminal-token-element:
-		CharacterRange(Keyword(x), Keyword(y)) -> CharClass(Simple(Present(Range(Short(x), Short(y)))))
+		CharacterRange(Keyword(from), Keyword(to)) -> CharClass(
+			Simple(
+				Present(
+					Range(
+						Short(<unquote(id)> from),
+						Short(<unquote(id)> to)
+				  )
+				)
+		  )
+		)
 	
 	gen-terminal-token-element:
-		RuleCall(reference) -> <fail>
-		where
-			<debug> "TODO"
+		RuleCall(reference) -> Sort(reference)
 		
+  /**
+   * Negated tokens require special attention, because they MUST be translated into SDF character classes but this mapping is less straightforward. 
+   */
 	gen-terminal-token-element:
-		NegatedToken(terminal-token-element) -> Comp(<gen-terminal-token-element> terminal-token-element)
+		NegatedToken(terminal-token-element) -> CiLit("'negated-token'")
+	where
+	  <debug> $[WARNING: Transforming negated tokens does not work correctly!]
 	
 	gen-terminal-token-element:
 		Wildcard(_) -> CharClass(Comp(Simple(Absent())))

--- a/Xtext/trans/generate/terminal-rule.str
+++ b/Xtext/trans/generate/terminal-rule.str
@@ -27,11 +27,14 @@ rules
 			; syntax-rules := <gen-terminal-token-element ; make-list> alternatives
 		  ; rhs          := <innermost(post-process-terminal-rule)> Rhs(syntax-rules)
   
+  /**
+   * Turn the head into a name. Head of a parserRule can be either a Fragment or Returns.
+   */
   gen-rule-name:
-  	Fragment(name) -> name
+  	Fragment(name) -> <sort-name> name
   
   gen-rule-name:
-  	Returns(name, _) -> name
+  	Returns(name, _) -> <sort-name> name
   
   /**
    * Turn a non-list into a list or return the given list
@@ -135,7 +138,7 @@ rules
 	 * Turn RuleCall into Sort
 	 */
 	gen-terminal-token-element:
-		RuleCall(reference) -> Sort(reference)
+		RuleCall(name) -> Sort(<sort-name> name)
 		
   /**
    * Negated tokens require special attention, because they MUST be translated into SDF character classes but this mapping is less straightforward. 

--- a/Xtext/trans/generate/terminal-rule.str
+++ b/Xtext/trans/generate/terminal-rule.str
@@ -94,10 +94,31 @@ rules
 	
 	list-to-alt:
 		[head | tail] -> Alt(head, <list-to-alt> tail)
+
+  /**
+   * Turn special keywords into character classes, or normal keywords into CiLits
+   */
+  gen-terminal-token-element:
+    Keyword(s) -> <gen-terminal-token-element-special + gen-terminal-token-element-normal>
+  
+  gen-terminal-token-element-special:
+    Keyword(char) -> CharClass(Simple(Present(Short(<unquote(id)> char))))
+  where
+    <gen-terminal-token-is-special> char
+  
+  gen-terminal-token-is-special:
+    char -> <true>
+  where
+    ?"'\\r'"
+  + ?"'\\n'"
+  + ?"'\\t'"
 	
-	gen-terminal-token-element:
-		Keyword(s) -> CiLit(s)
-	
+  gen-terminal-token-element-normal:
+     Keyword(s) -> CiLit(s)
+  
+  /**
+   * Turn CharacterRange into CharClass
+   */
 	gen-terminal-token-element:
 		CharacterRange(Keyword(from), Keyword(to)) -> CharClass(
 			Simple(
@@ -110,6 +131,9 @@ rules
 		  )
 		)
 	
+	/**
+	 * Turn RuleCall into Sort
+	 */
 	gen-terminal-token-element:
 		RuleCall(reference) -> Sort(reference)
 		
@@ -121,5 +145,8 @@ rules
 	where
 	  <debug> $[WARNING: Transforming negated tokens does not work correctly!]
 	
+	/**
+	 * Turn Wildcard into the complement of an empty CharClass
+	 */
 	gen-terminal-token-element:
 		Wildcard(_) -> CharClass(Comp(Simple(Absent())))


### PR DESCRIPTION
A lot of cleanup in the generation of Terminal tokens. E.g. removing unnecessary parenthesis, replace control characters, and cleaning sort names.
