### PR TITLE
Add associativity to priority groups

### DIFF
--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -135,8 +135,6 @@ rules // Pattern match left- and right associative ParserRules
       ])
     ])) -> <true>
   where
-    debug;
-    <debug> 5;
     <is-left-assoc-tokens> tokens
   
   is-left-assoc-tokens:

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -15,6 +15,7 @@ imports
 	generate/xtext-lift-alternative
 	generate/xtext-obtain-priorities
 	generate/add-actions
+	generate/sdf-priority-groups
 	
 rules
 	
@@ -31,17 +32,18 @@ rules
 			filename := $[[<remove-extension> path].sdf3.aterm]
 	
 	gen-sdf-debug:
-	  (ast, priorities) -> sdf-with-priorities
+	  (ast, priorities) -> priorities-with-assoc
 	where
-	  sdf                 := <gen-sdf-debug> ast
-	; sdf-with-priorities := <add-priorities> (sdf, priorities)
+	  sdf                   := <gen-sdf-debug> ast
+	; sdf-with-priorities   := <add-priorities> (sdf, priorities)
+	; priorities-with-assoc := <innermost(priority-group(|sdf-with-priorities))> sdf-with-priorities
 	  
 	add-priorities:
 	  (Module(x, y, sections), priorities) -> Module(x, y, <append> (sections, priorities))
 	
 	gen-sdf-debug:
-		selected -> <(gen-grammar + gen-rule) ; topdown(try(post))> selected
-	
+		selected -> <(gen-grammar + gen-rule) ; topdown(try(post))> selected 
+  
 	gen-sdf-debug:
 		selected -> <map(gen-sdf-debug)> selected
 		where

--- a/Xtext/trans/generate/sdf-priority-groups.str
+++ b/Xtext/trans/generate/sdf-priority-groups.str
@@ -1,0 +1,28 @@
+module sdf-priority-groups
+
+imports
+  
+  include/Xtext
+  include/TemplateLang
+  
+rules
+  
+  /**
+   * Add associativity to the priority group
+   * 
+   * @type ProdsRefGroup -> AssocRefGroup
+   */
+  priority-group(|ast):
+    ProdsRefGroup([SortConsRef(Sort(sort), Constructor(cons))]) -> AssocRefGroup(associativity, [SortConsRef(Sort(sort), Constructor(cons))])
+  where
+  	associativity := <get-assoc(|ast)> (sort, cons)
+  
+  /**
+   * Get associativity for the given Sort.Cons
+   */ 
+  get-assoc(|ast):
+  	(sort, cons) -> <collect-one(
+      ?SdfProductionWithCons(
+        SortCons(SortDef(sort), Constructor(cons)), _, Attrs([Assoc(<id>)])
+      )
+    )> ast

--- a/Xtext/trans/generate/xtext-complex-list.str
+++ b/Xtext/trans/generate/xtext-complex-list.str
@@ -10,8 +10,6 @@ rules
 	
 	replace-complex-list:
 		input -> <try(find-consecutive-elements(find-list-initiator, find-list-tail))> input
-	where
-	  <debug> input
 	
 	find-consecutive-elements(filter1, filter2):
 		[head | [head_tail | tail]] -> <flatten-list> out

--- a/Xtext/trans/generate/xtext-expand-any.str
+++ b/Xtext/trans/generate/xtext-expand-any.str
@@ -13,9 +13,7 @@ rules
 			<oncetd(mandatory(|abstract-terminal-token))> p
 		]
 	where
-		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives;
-		<debug> <oncetd(remove(|abstract-terminal-token))> p;
-		<debug> <oncetd(mandatory(|abstract-terminal-token))> p
+		abstract-terminal-token := <collect-one(is-abstract-terminal-token)> alternatives
 	
 	is-abstract-terminal-token =
 		?AbstractTerminalAbstractToken(_, Some(Any()))

--- a/Xtext/trans/generate/xtext-obtain-priorities.str
+++ b/Xtext/trans/generate/xtext-obtain-priorities.str
@@ -11,8 +11,7 @@ rules
 		ast -> <try(remove-return)> (ast, priorities)
   where
 		chains     := <collect-all(gen-priorities(|ast)); flatten-list> ast;
-		cleaned    := <try(cleanup_priorities)> chains;
-		priorities := SDFSection(ContextFreePriorities(cleaned))
+		priorities := SDFSection(ContextFreePriorities(chains))
 	
 	//Removing rules of type Exp = Exp can more easily be done in SDF
 	


### PR DESCRIPTION
Fixes a part of #31, though we still need to condense the priority groups.
