### PR TITLE
Fix fail if no parser rules (fixes #53)

### DIFF
--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -43,17 +43,15 @@ rules
 	
 	gen-sdf-debug:
 		selected -> <(gen-grammar + gen-rule) ; topdown(try(post))> selected 
-  
-	gen-sdf-debug:
-		selected -> <map(gen-sdf-debug)> selected
-		where
-			<is-list> selected
 	
 	// Menu
 	gen-xtext-sdf:
-		(selected, position, ast, path, project-path) -> (filename, <gen-xtext ; gen-sdf-debug ; sdf-pp> selected)
+		(selected, position, ast, path, project-path) -> (filename, result)
 		where
 			filename := $[[<remove-extension> path].sdf3]
+		; xtext    := <gen-xtext> selected
+		; sdf      := <gen-sdf-debug> xtext
+		; result   := <sdf-pp> sdf
 	
 	// Menu
 	gen-xtext:
@@ -61,10 +59,14 @@ rules
 		where
 			filename := <guarantee-extension(|"xtextng.aterm")> path
 	
-	// Desugar selection.
-	// - Do a flatten-list over the whole tree afterwards to prevent nested parser rules directly in a Grammar()
-	// - Do a add-action over the whole tree afterwards to add actions where necessary
-	// - Extract priorities from Xtext and return a pair (xtext grammar, sdf priorities)
+	/**
+	 * Desugar selection.
+	 * - Do a flatten-list over the whole tree afterwards to prevent nested parser rules directly in a Grammar()
+	 * - Do a add-action over the whole tree afterwards to add actions where necessary
+	 * - Extract priorities from Xtext and return a pair (xtext grammar, sdf priorities)
+	 *
+	 * @type Xtext AST -> (modified Xtext AST, priority tuples)
+	 */
 	gen-xtext:
 		ast -> xtext-with-priorities
 	  where

--- a/Xtext/trans/generate/parser-rule.str
+++ b/Xtext/trans/generate/parser-rule.str
@@ -12,20 +12,23 @@ imports
 	generate/common
 	generate/generate
 	generate/terminal-rule
-  	generate/xtext-complex-list
-  	generate/xtext-extract-crossreferences
+	generate/xtext-complex-list
+	generate/xtext-extract-crossreferences
   
-rules 
+rules
 	
 	gen-grammar:
 		Grammar(GrammarID(names), mixin, _, _, abstract-rules) -> Module(name,imports,sdf-sections)
 		where
-			name               := <id-to-name> names;
-			imports			   := <gen-imports> mixin;
-			start-symbol	   := <fetch-elem(gen-start-symbol)> abstract-rules;
-			reference-rules	   := <gen-crossreference-rules> abstract-rules;
-			sdf-sections	   := [start-symbol | <conc>(<map(gen-rule)> abstract-rules, reference-rules)]
-		
+			name            := <id-to-name> names;
+			imports         := <gen-imports> mixin;
+			reference-rules := <gen-crossreference-rules> abstract-rules;
+			if <fetch-elem(gen-start-symbol)> abstract-rules then
+			  sdf-sections  := [<fetch-elem(gen-start-symbol)> abstract-rules | <conc>(<map(gen-rule)> abstract-rules, reference-rules)]
+			else
+			  sdf-sections  := [<conc>(<map(gen-rule)> abstract-rules, reference-rules)]
+			end
+			
 	gen-imports:
 		None() -> []
 		


### PR DESCRIPTION
As described in #53, the transformation fails if the input contains no parser rules. This PR fixes the issue. After this is merged we can safely transform Terminals.xtext, _except for the UntilToken._

@JeffGoderie could you check the code and merge if it's ok?
