### PR TITLE
Associativity fix

### DIFF
--- a/Xtext/tests/associativity.str
+++ b/Xtext/tests/associativity.str
@@ -14,6 +14,7 @@ strategies
     ; test-is-right-assoc-simple
     ; test-left-is-not-right-assoc
     ; test-right-is-not-left-assoc
+    ; test-left-assoc-same-sort
     )
 
   test-is-left-assoc-simple =
@@ -48,4 +49,13 @@ strategies
     , <parse-xtext-string> "
         Add returns Expression:
           Mul ({Add.left=current} '+' right=Add)?;"
+    )
+  
+  test-left-assoc-same-sort =
+    apply-and-fail(!"the left-assoc pattern requires rules with the same sort"
+    , is-left-assoc
+    , <parse-xtext-string> "
+        Expression:
+          TerminalExpression ({Selection.receiver=current} '.' message=Message )*
+        ;"
     )

--- a/Xtext/tests/complex_list.str
+++ b/Xtext/tests/complex_list.str
@@ -1,143 +1,145 @@
 module complex_list
 
 imports
-	generate/xtext-complex-list
-	libstratego-lib
-  	include/Xtext
-  	include/TemplateLang
+  libstratego-lib
+  lib/editor-common.generated
+  include/Xtext
+  include/TemplateLang
+  generate/xtext-complex-list
 
 strategies
-  	main =
-	test-suite(!"complex_list",
-  		list-empty;
-  		list-too-small;
-  		no-complex-list;
-  		inverted-complex-list;
-  		complex-list-suffix-list;
-		prefix-list-complex-list;
-  		complex-list
-	)
-    
-  	list-empty =
-    apply-test(!"list-empty",
-      	replace-complex-list,
-     	![],
-      	![]
+  main =
+    test-suite(!"complex_list"
+    , list-empty
+    ; list-too-small
+    ; no-complex-list
+    ; inverted-complex-list
+    ; complex-list-suffix-list
+    ; prefix-list-complex-list
+    ; complex-list
     )
     
-  	list-too-small =
-    apply-test(!"list-too-small",
-      	replace-complex-list,
-      	![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())],
-      	![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())]
-    )
+    list-empty =
+      apply-test(!"list-empty",
+        replace-complex-list,
+        ![],
+        ![]
+      )
     
-  	no-complex-list = 
-	apply-test(!"no-complex-list",
-	  	replace-complex-list,
-	  	![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None()), AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())],
-	  	![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None()), AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())]
-	)
-  	
-  	inverted-complex-list =
-    apply-test(!"inverted-complex-list",
-      replace-complex-list,
-      ![AbstractTerminalAbstractToken(
-		    Alternatives(
-		      [ UnorderedGroup(
-		          [ Group(
-		              [ AbstractTerminalAbstractToken(Keyword("','"), None())
-		              , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-		              ]
-		            )
-		          ]
-		        )
-		      ]
-		    )
-		  , Some(Any())
-		),      	
-	    AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())],
-      ![AbstractTerminalAbstractToken(
-		    Alternatives(
-		      [ UnorderedGroup(
-		          [ Group(
-		              [ AbstractTerminalAbstractToken(Keyword("','"), None())
-		              , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-		              ]
-		            )
-		          ]
-		        )
-		      ]
-		    )
-		  , Some(Any())
-		),      	
-	    AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())]
-    )
+    list-too-small =
+      apply-test(!"list-too-small",
+        replace-complex-list,
+        ![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())],
+        ![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())]
+      )
+    
+    no-complex-list = 
+      apply-test(!"no-complex-list",
+        replace-complex-list,
+        ![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None()), AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())],
+        ![AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None()), AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())]
+      )
+    
+    inverted-complex-list =
+      apply-test(!"inverted-complex-list",
+        replace-complex-list
+      , ![AbstractTerminalAbstractToken(
+	          Alternatives(
+	            [ UnorderedGroup(
+	                [ Group(
+	                    [ AbstractTerminalAbstractToken(Keyword("','"), None())
+	                    , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	                    ]
+	                  )
+	                ]
+	              )
+	            ]
+	          )
+	        , Some(Any())
+	      ),
+	      AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	      ],
+	      ![AbstractTerminalAbstractToken(
+	        Alternatives(
+	          [ UnorderedGroup(
+	              [ Group(
+	                  [ AbstractTerminalAbstractToken(Keyword("','"), None())
+	                  , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	                  ]
+	                )
+	              ]
+	            )
+	          ]
+	        )
+	      , Some(Any())
+	      ),        
+        AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())]
+      )
     
     complex-list =
-    apply-test(!"complex-list",
-      	replace-complex-list,
-     	![ AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-			, AbstractTerminalAbstractToken(
-			    Alternatives(
-			      [ UnorderedGroup(
-			          [ Group(
-			              [ AbstractTerminalAbstractToken(Keyword("','"), None())
-			              , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-			              ]
-			            )
-			          ]
-			        )
-			      ]
-			    )
-			  , Some(Any())
-			  )
-			],
-			![IterSep(Label(Unquoted("p"), RuleCall("Q")), Keyword("','"))]
-	)
-	
-	complex-list-suffix-list =
-    apply-test(!"complex-list-suffix-list",
-      	replace-complex-list,
-     	![ AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-			, AbstractTerminalAbstractToken(
-			    Alternatives(
-			      [ UnorderedGroup(
-			          [ Group(
-			              [ AbstractTerminalAbstractToken(Keyword("','"), None())
-			              , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-			              ]
-			            )
-			          ]
-			        )
-			      ]
-			    )
-			  , Some(Any())
-			  )
-			, AbstractTerminalAbstractToken(Keyword("a"), None())
-			],
-			![IterSep(Label(Unquoted("p"), RuleCall("Q")), Keyword("','")), AbstractTerminalAbstractToken(Keyword("a"), None())]
-	)
-	
-	prefix-list-complex-list =
-    apply-test(!"prefix-list-complex-list",
-      	replace-complex-list,
-     	![  AbstractTerminalAbstractToken(Keyword("a"), None()),
-     		AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-			, AbstractTerminalAbstractToken(
-			    Alternatives(
-			      [ UnorderedGroup(
-			          [ Group(
-			              [ AbstractTerminalAbstractToken(Keyword("','"), None())
-			              , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
-			              ]
-			            )
-			          ]
-			        )
-			      ]
-			    )
-			  , Some(Any())
-			  )
-			],
-			![AbstractTerminalAbstractToken(Keyword("a"), None()), IterSep(Label(Unquoted("p"), RuleCall("Q")),Keyword("','"))]
-	)
+      apply-test(!"complex-list",
+        replace-complex-list,
+	      ![ AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	      , AbstractTerminalAbstractToken(
+	          Alternatives(
+	            [ UnorderedGroup(
+	                [ Group(
+	                    [ AbstractTerminalAbstractToken(Keyword("','"), None())
+	                    , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	                    ]
+	                  )
+	                ]
+	              )
+	            ]
+	          )
+	        , Some(Any())
+	        )
+	      ],
+	      ![(IterSep(Label(Quoted("\"p\""), Sort("Q")), Lit("\",\"")), [])]
+      )
+  
+  complex-list-suffix-list =
+    apply-test(!"complex-list-suffix-list"
+    , replace-complex-list
+    , ![ AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+      , AbstractTerminalAbstractToken(
+          Alternatives(
+            [ UnorderedGroup(
+                [ Group(
+                    [ AbstractTerminalAbstractToken(Keyword("','"), None())
+                    , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+                    ]
+                  )
+                ]
+              )
+            ]
+          )
+        , Some(Any())
+        )
+      , AbstractTerminalAbstractToken(Keyword("a"), None())
+      ]
+    , ![(IterSep(Label(Quoted("\"p\""), Sort("Q")), Lit("\",\"")), []), AbstractTerminalAbstractToken(Keyword("a"), None())]
+  )
+  
+  prefix-list-complex-list =
+    apply-test(!"prefix-list-complex-list"
+	  , replace-complex-list
+	  , ![AbstractTerminalAbstractToken(Keyword("a"), None()),
+	        AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	      , AbstractTerminalAbstractToken(
+	          Alternatives(
+	            [ UnorderedGroup(
+	                [ Group(
+	                    [ AbstractTerminalAbstractToken(Keyword("','"), None())
+	                    , AssignmentAbstractToken(None(), "p", AddAssignment(), RuleCall("Q"), None())
+	                    ]
+	                  )
+	                ]
+	              )
+	            ]
+	          )
+	        , Some(Any())
+	        )
+	    ]
+	  , ![AbstractTerminalAbstractToken(Keyword("a"), None()), (IterSep(Label(Quoted("\"p\""), Sort("Q")),Lit("\",\"")), [])]
+    )

--- a/Xtext/trans/generate/common.str
+++ b/Xtext/trans/generate/common.str
@@ -140,8 +140,8 @@ rules // Pattern match left- and right associative ParserRules
   is-left-assoc-tokens:
     tokens -> <true>
   where
-    // "<first> tokens" is a RuleCall or a Keyword (we're more liberal here)
-    !tokens; ?[AbstractTerminalAbstractToken(_, None()) | _];
+    // "<first> tokens" is a RuleCall with a name
+    ?[AbstractTerminalAbstractToken(RuleCall(name), None()) | _];
     
     // "<last> tokens > group" has cardinality any
     <last> tokens; ?AbstractTerminalAbstractToken(Alternatives([UnorderedGroup([Group(sub-tokens)])]), Some(Any()));
@@ -149,8 +149,8 @@ rules // Pattern match left- and right associative ParserRules
     // "<last> tokens > group" starts with an action which assigns 'current'
     !sub-tokens; ?[ActionAbstractToken(Action(TypeRef(None(), _), Some(ActionCurrent(_, Assignment())))) | _];
     
-    // "<last> tokens > group" ends with an action which assigns 'current'
-    <last> sub-tokens; ?AssignmentAbstractToken(None(), _, Assignment(), RuleCall(_), None())
+    // "<last> tokens > group" ends with an assignment that calls a rule with the same name as above
+    <last> sub-tokens; ?AssignmentAbstractToken(None(), _, Assignment(), RuleCall(name), None())
   
   is-right-assoc:
     ParserRule(name, _, _, Alternatives([UnorderedGroup([Group(tokens)])])) -> <true>


### PR DESCRIPTION
Stricter left-associativity pattern matching. Now we require a RuleCall with a name, and the name should be the same as the name later on. The following will be left-associative:

```
X ({C.l=current} "+" r=X)
```

but this will not because X != Y:

```
X ({C.l=current} "+" r=Y)
```

I also had to fix a few complex list test cases in order to run the test suite. You can safely ignore these changes.

Fixes #64
