### PR TITLE
Add refactor action

### DIFF
--- a/Xtext/editor/Xtext-Menus.esv
+++ b/Xtext/editor/Xtext-Menus.esv
@@ -32,8 +32,8 @@ menus
   
   menu: "Generation"                   (openeditor) (realtime)
 
-    action: "Generate Xtext"                 = gen-xtext
-    action: "Generate Xtext > SDF"           = gen-xtext-sdf
-    action: "Generate Xtext > SDF > Nolabel" = gen-xtext-sdf-nolabel
-    action: "Generate SDF (ATerm)"           = gen-sdf
-    action: "Generate SDF"                   = gen-sdf-file
+    action: "Generate Xtext"                 = menu-gen-xtext
+    action: "Generate Xtext > SDF"           = menu-gen-xtext-sdf
+    action: "Generate Xtext > SDF > Nolabel" = menu-gen-xtext-sdf-nolabel
+    action: "Generate SDF (ATerm)"           = menu-gen-sdf
+    action: "Generate SDF"                   = menu-gen-sdf-file

--- a/Xtext/editor/Xtext-Refactorings.esv
+++ b/Xtext/editor/Xtext-Refactorings.esv
@@ -4,9 +4,13 @@ imports
 
   Xtext-Refactorings.generated
 
+keybindings
+
+  Shift + Alt + R = "xtext.refactor"
+
 refactorings
 
   text reconstruction : construct-textual-change
   
-  refactoring AbstractRule.ParserRule : "To SDF" = refactor-to-sdf
-    
+  refactoring AbstractRule.ParserRule : "To SDF" = refactor-to-sdf (cursor)
+  shortcut: Shift + Alt + R

--- a/Xtext/editor/Xtext-Refactorings.esv
+++ b/Xtext/editor/Xtext-Refactorings.esv
@@ -1,7 +1,12 @@
 module Xtext-Refactorings
 
-imports Xtext-Refactorings.generated
+imports
+
+  Xtext-Refactorings.generated
 
 refactorings
 
   text reconstruction : construct-textual-change
+  
+  refactoring AbstractRule.ParserRule : "To SDF" = refactor-to-sdf
+    

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -26,15 +26,15 @@ rules // Printing SDF
   
 rules // Generating SDF
 	
-	// Menu: "Generate SDF"
-	gen-sdf-file:
+	// "Generate SDF"
+	menu-gen-sdf-file:
 		(selected, position, ast, path, project-path) -> (filename, <sdf-pp> sdf)
 		where
 			filename := <guarantee-extension(|"sdf3")> path
 		; sdf      := <gen-sdf-debug> selected
 	
-	// Menu: "Generate SDF (ATerm)"
-	gen-sdf:
+	// "Generate SDF (ATerm)"
+	menu-gen-sdf:
 		(selected, position, ast, path, project-path) -> (filename, <gen-sdf-debug> selected)
 		where
 			filename := <guarantee-extension(|"sdf3.aterm")> path
@@ -53,16 +53,16 @@ rules // Generating SDF
 	gen-sdf-debug:
 		ast -> <(gen-grammar(|ast) + gen-rule(|ast)); topdown(try(post))> ast
 	
-	// Menu: "Generate Xtext > SDF > Nolabel"
-	gen-xtext-sdf-nolabel:
+	// "Generate Xtext > SDF > Nolabel"
+	menu-gen-xtext-sdf-nolabel:
 	  (selected, position, ast, path, project-path) -> (filename, result)
 	where
     dirname  := <dirname> path
   ; filename := <guarantee-extension(|"sdf3")> path
   ; result   := <gen-xtext-sdf(|dirname); topdown(try(?Label(_, <id>))); sdf-pp> selected
   
-	// Menu: "Generate Xtext > SDF
-	gen-xtext-sdf:
+	// "Generate Xtext > SDF
+	menu-gen-xtext-sdf:
 		(selected, position, ast, path, project-path) -> (filename, result)
 	where
     dirname  := <dirname> path
@@ -107,8 +107,8 @@ rules // Generating SDF
 
 rules // Generating intermediate Xtext
   
-	// Menu: "Generate Xtext"
-	gen-xtext:
+	// "Generate Xtext"
+	menu-gen-xtext:
 		(selected, _, _, path, _) -> (filename, <gen-xtext> selected)
 		where
 			filename := <guarantee-extension(|"xtextng.aterm")> path

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -43,13 +43,9 @@ rules // Generating SDF
 	  (ast, priorities) -> cleaned-up-priorities
 	where
 	  sdf                   := <gen-sdf-debug> ast
-	; <debug> "Now add priorities"
 	; sdf-with-priorities   := <add-priorities> (sdf, priorities)
-	; <debug> "Added priorities"
 	; priorities-with-assoc := <innermost(priority-group(|sdf-with-priorities))> sdf-with-priorities
-	; <debug> "SDF with priorities"
 	; cleaned-up-priorities := <innermost(cleanup_priorities)> priorities-with-assoc
-	; <debug> "Cleaned priorities"
 	  
 	add-priorities:
 	  (Module(x, y, sections), priorities) -> Module(x, y, <append> (sections, priorities))
@@ -59,9 +55,6 @@ rules // Generating SDF
 	
 	gen-sdf-debug:
 		ast -> <(gen-grammar(|ast) + gen-rule(|ast)); topdown(try(post))> ast
-  where
-    <debug> "De rule is:"
-  ; <debug> <gen-rule(|ast)> ast
 	
 	// "Generate Xtext > SDF > Nolabel"
 	menu-gen-xtext-sdf-nolabel:

--- a/Xtext/trans/generate/generate.str
+++ b/Xtext/trans/generate/generate.str
@@ -43,15 +43,25 @@ rules // Generating SDF
 	  (ast, priorities) -> cleaned-up-priorities
 	where
 	  sdf                   := <gen-sdf-debug> ast
+	; <debug> "Now add priorities"
 	; sdf-with-priorities   := <add-priorities> (sdf, priorities)
+	; <debug> "Added priorities"
 	; priorities-with-assoc := <innermost(priority-group(|sdf-with-priorities))> sdf-with-priorities
+	; <debug> "SDF with priorities"
 	; cleaned-up-priorities := <innermost(cleanup_priorities)> priorities-with-assoc
+	; <debug> "Cleaned priorities"
 	  
 	add-priorities:
 	  (Module(x, y, sections), priorities) -> Module(x, y, <append> (sections, priorities))
 	
+	add-priorities:
+	  (sdf, _) -> sdf
+	
 	gen-sdf-debug:
 		ast -> <(gen-grammar(|ast) + gen-rule(|ast)); topdown(try(post))> ast
+  where
+    <debug> "De rule is:"
+  ; <debug> <gen-rule(|ast)> ast
 	
 	// "Generate Xtext > SDF > Nolabel"
 	menu-gen-xtext-sdf-nolabel:
@@ -59,7 +69,12 @@ rules // Generating SDF
 	where
     dirname  := <dirname> path
   ; filename := <guarantee-extension(|"sdf3")> path
-  ; result   := <gen-xtext-sdf(|dirname); topdown(try(?Label(_, <id>))); sdf-pp> selected
+  ; result   := <gen-xtext-sdf-nolabel(|dirname)> selected
+  
+  gen-xtext-sdf-nolabel(|dirname):
+    ast -> result
+  where
+    result := <gen-xtext-sdf(|dirname); topdown(try(?Label(_, <id>))); sdf-pp> ast
   
 	// "Generate Xtext > SDF
 	menu-gen-xtext-sdf:
@@ -72,8 +87,8 @@ rules // Generating SDF
 	gen-xtext-sdf(|dirname):
 	  ast -> sdf
 	where
-    xtext    := <gen-xtext> ast
-  ; sdf      := <gen-sdf-debug> xtext
+    xtext := <gen-xtext> ast
+  ; sdf   := <gen-sdf-debug> xtext
 	; <mixin-get; map(mixin-generate(|dirname))> ast
 	
 	mixin-get:

--- a/Xtext/trans/refactor/refactor.str
+++ b/Xtext/trans/refactor/refactor.str
@@ -8,13 +8,7 @@ imports
 rules
 	
   refactor-to-sdf:
-    (newname, selected, position, ast, path, project-path) -> ([(selected, new-ast)], fatal-errors, errors, warnings)
+    (newname, selected, position, ast, path, project-path) -> ([(selected, new-ast)], [], [], [])
   where
-  	<dbg(|"refactor")> "a"
-  ; dirname := <dirname> path
-  ; <dbg(|"refactor")> "aa"
+    dirname := <dirname> path
   ; new-ast := <gen-xtext-sdf-nolabel(|dirname)> selected
-  ; <dbg(|"refactor")> "b"
-  ; (errors, warnings) := /*<check-semantics> (ast, new-ast)*/ ([], [])
-  ; <dbg(|"refactor")> "c"
-  ; fatal-errors := []

--- a/Xtext/trans/refactor/refactor.str
+++ b/Xtext/trans/refactor/refactor.str
@@ -1,0 +1,20 @@
+module refactor
+
+imports
+	
+	generate/generate
+	include/TemplateLang
+	
+rules
+	
+  refactor-to-sdf:
+    (newname, selected, position, ast, path, project-path) -> ([(selected, new-ast)], fatal-errors, errors, warnings)
+  where
+  	<dbg(|"refactor")> "a"
+  ; dirname := <dirname> path
+  ; <dbg(|"refactor")> "aa"
+  ; new-ast := <gen-xtext-sdf-nolabel(|dirname)> selected
+  ; <dbg(|"refactor")> "b"
+  ; (errors, warnings) := /*<check-semantics> (ast, new-ast)*/ ([], [])
+  ; <dbg(|"refactor")> "c"
+  ; fatal-errors := []

--- a/Xtext/trans/xtext.str
+++ b/Xtext/trans/xtext.str
@@ -19,6 +19,7 @@ imports
 	check
 	generate/-
 	generate/generate
+	refactor/refactor
 	pp
 
 rules // Analysis


### PR DESCRIPTION
This PR enables users to transform only parts of their program by means of a refactoring. This is especially useful when our tool is used to partially translate by hand/partially translate by machine. However, it should be used only for small parts. At some point the parser won't parse the mixture of Xtext and SDF.

The refactoring is accessible from the context menu (select a parser rule, right click, "Refactor", "To SDF") and via the shortcut Sift + Alt + R (or Cmd + Option + R on OS X).

I had no prior experience with refactorings, but it turns out to be really easy to setup:
- http://metaborg.org/spoofax/tour/#refactorings
- http://metaborg.org/spoofax/editor-services/#refactorings
- http://swerl.tudelft.nl/twiki/pub/Main/TechnicalReports/TUD-SERG-2013-008.pdf
