### PR TITLE
Refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://dl.bintray.com/martijndwars/xtext/
 
 ## Usage
 
-After installing the transformer you can either:
+After installing the transformer you can do one of the following:
 
-1. transform a piece of Xtext by selecting it using the 'Refactor' option in the context menu (e.g. an Xtext ParserRule)
-2. transform a complete file by using the builder
+- transform a ParserRule or EnumRule by selecting it and then using the 'Refactor' > 'To SDF' option from the context menu (or use Cmd + Alt + R on OS X, Shift + Alt + R on Windows).
+- transform a complete file by using the builder

--- a/nl.tudelft.xtext/editor/Xtext-Refactorings.esv
+++ b/nl.tudelft.xtext/editor/Xtext-Refactorings.esv
@@ -12,5 +12,5 @@ refactorings
 
   text reconstruction : construct-textual-change
   
-  refactoring AbstractRule.ParserRule : "To SDF" = refactor-to-sdf (cursor)
+  refactoring AbstractRule : "To SDF" = refactor-to-sdf (cursor)
   shortcut: Shift + Alt + R

--- a/nl.tudelft.xtext/trans/generate/enum-rule.str
+++ b/nl.tudelft.xtext/trans/generate/enum-rule.str
@@ -8,23 +8,21 @@ imports
 
 rules
 	
-	// gen-rule:
-	// 	EnumRule(name, enum-literals) -> $[
-	// 		lexical syntax
-	// 	    	[<map(gen-enum-literal ; prefix(|name)) ; separate-by(|"\n") ; concat-strings> enum-literals]
-	// 	]
-		
-	gen-rule:
-		EnumRule(name, enum-literals) -> SDFSection(LexicalSyntax(<map(gen-enum-literal(|name))> enum-literals))
-	
-	// gen-enum-literal:
-	// 	EnumLiteral(name) -> $["[name]"]
-	
+  gen-rule(|ast):
+    e@EnumRule(name, enum-literals) -> SDFSection(LexicalSyntax(<gen-rule-sub> e))
+  where
+    <debug> enum-literals
+
+	gen-rule(|ast):
+	  enum-rules -> SDFSection(LexicalSyntax(<map(gen-rule-sub)> enum-rules))
+	where
+	  <is-list> enum-rules
+  
+  gen-rule-sub:
+    EnumRule(name, enum-literals) -> <map(gen-enum-literal(|name))> enum-literals
+  
 	gen-enum-literal(|name):
 		EnumLiteral(value) -> SdfProduction(SortDef(name), Rhs([Lit(<double-quote> value)]), NoAttrs())
 	
 	gen-enum-literal(|name):
 		EnumLiteral(_, value) -> SdfProduction(SortDef(name), Rhs([Lit(<double-quote> value)]), NoAttrs())
-	
-	// prefix(|name):
-	// 	result -> $[[name] = [result]]

--- a/nl.tudelft.xtext/trans/generate/parser-rule.str
+++ b/nl.tudelft.xtext/trans/generate/parser-rule.str
@@ -38,23 +38,36 @@ rules
 	gen-import-name:
 		GrammarID(names) -> Module(name)
 		where
-			name			:= <id-to-name> names
+			name := <id-to-name> names
 
 	gen-start-symbol:
 		ParserRule(name, _, _, _) -> SDFSection(ContextFreeStartSymbols([Sort(name)]))
   
+  // Transform a single ParserRule
 	gen-rule(|ast):
 		p@ParserRule(name, _,_, alternatives) -> SDFSection(ContextFreeSyntax(alts-with-assoc))
 		where
-			alts := <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
-		; if <is-left-assoc> p then
-		    alts-with-assoc := <add-associativity(|Left())> alts
-		  else if <is-right-assoc> p then
-	      alts-with-assoc := <add-associativity(|Right())> alts
-	    else
-	      alts-with-assoc := alts
-	    end end
+		  alts-with-assoc := <gen-rule-sub(|ast)> p
 	
+	// Transform a list of ParserRule's
+	gen-rule(|ast):
+	  parser-rules -> SDFSection(ContextFreeSyntax(<map(gen-rule-sub(|ast))> parser-rules))
+	where
+	  <is-list> parser-rules
+ 
+  // Common functionality for transforming either list/single ParserRule
+	gen-rule-sub(|ast):
+	  p@ParserRule(name, _,_, alternatives) -> alts-with-assoc
+    where
+      alts := <gen-alternatives(|SortDef(name), NoAttrs())> alternatives
+    ; if <is-left-assoc> p then
+        alts-with-assoc := <add-associativity(|Left())> alts
+      else if <is-right-assoc> p then
+        alts-with-assoc := <add-associativity(|Right())> alts
+      else
+        alts-with-assoc := alts
+      end end
+
 	add-associativity(|associativity):
 	  productions -> <map(try(add-associativity(|associativity)))> productions
 	where


### PR DESCRIPTION
A mall bug fix: in a early stage, alternatives are expanded into multiple rules (both in ParserRule's and in EnumRule's). So when interactively refactoring a single (Parser|Enum)Rule the strategy is fed a _list_ instead. Previously, the `gen-rule` strategies for ParserRule and EnumRule were unable to handle lists. Now, they output a single SDFSection with ContextFreeSyntax resp. LexicalSyntax and the result of mapping over the list.
