### PR TITLE
Escape fix

### DIFF
--- a/nl.tudelft.xtext/tests/restriction.str
+++ b/nl.tudelft.xtext/tests/restriction.str
@@ -1,0 +1,86 @@
+module restriction
+
+imports
+  libstratego-lib
+  lib/editor-common.generated
+  include/Xtext
+  lib/TemplateLang
+  trans/generate/common
+  trans/generate/restrictions
+
+strategies
+  main =
+    test-suite(!"restriction",
+      test-fold-alt-simple
+    ; test-fold-alt-mixed
+    ; test-fold-alt-hard
+    )
+    
+  test-fold-alt-simple =
+    apply-and-check(!"Test folding of alt (simple)"
+    , fold-alt(merge-class)
+    , !Alt(
+        CharClass(Simple(Present(Short("\\r"))))
+      , CharClass(Simple(Present(Short("\\n"))))
+      )
+    , !CharClass(
+        Simple(
+        	Present(
+      			Conc(
+      				Short("\\r")
+      			, Short("\\r")
+    			  )
+          )
+        )
+      )
+    )
+
+  test-fold-alt-mixed =
+    apply-and-check(!"Test folding of alt (mixed CiLit and CharClass)"
+    , fold-alt(unordered(merge-class))
+    , !Alt(
+        CiLit("' '")
+      , CharClass(Simple(Present(Short("\\t"))))
+      )
+    , !CharClass(
+        Simple(
+        	Present(
+        		Conc(
+        			Short("\\t")
+        		, Short("\\ ")
+      			)
+    			)
+        )
+      )
+    )
+
+  test-fold-alt-hard =
+    apply-and-check(!"Test folding of alt (hard)"
+    , fold-alt(unordered(merge-class))
+    , !Alt(
+        CiLit("' '")
+      , Alt(
+          CharClass(Simple(Present(Short("\\t"))))
+        , Alt(
+            CharClass(Simple(Present(Short("\\r"))))
+          , CharClass(Simple(Present(Short("\\n"))))
+          )
+        )
+      )
+    , !CharClass(
+      	Simple(
+      		Present(
+      			Conc(
+      				Conc(
+      					Short("\\t")
+    					, Conc(
+    					    Short("\\r")
+    					  , Short("\\n")
+  					    )
+					    ),
+				      Short("\\ ")
+			      )
+		      )
+	      )
+      )
+    )

--- a/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
+++ b/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
@@ -84,9 +84,6 @@ rules
 	is-duplicated-sortcons(|ast):
 		a@SdfProductionWithCons(SortCons(SortDef(name), Constructor(cons)), e@Rhs(elements), attr) -> new_rule
 		where
-			<debug> "begin";
-			<debug> a;
-			<debug> "end";
 			<not(?[_] + ?[])> <collect-all(?SdfProductionWithCons(SortCons(SortDef(name), Constructor(cons)), _, _))> ast;
 			suffix := <map(get-element)> elements;
 			new_cons := <concat-strings> [cons| suffix];
@@ -102,16 +99,15 @@ rules
 	remove-stupid:
 		ast -> new_ast
 		where
-			(name, cons) := <debug><fetch-elem(is-converted-subrule)> ast;
-			<debug> <collect-all(?SdfProductionWithCons(SortCons(SortDef(name), _), _, _) + ?SdfProduction(SortDef(name), _,_)); debug; ?[_]> ast;
-			<debug> ast;
+			(name, cons) := <fetch-elem(is-converted-subrule)> ast;
+			<collect-all(?SdfProductionWithCons(SortCons(SortDef(name), _), _, _) + ?SdfProduction(SortDef(name), _,_)); ?[_]> ast;
 			new_ast := <try(remove-stupid)> <topdown(try((SortDef(name) -> SortDef(cons)) + (Sort(name) -> Sort(cons)) + (string-replace(|name, cons))))> ast
 	
 	remove-stupid:
 		ast -> new_ast
 		where
-			(name, cons) := <debug><fetch-elem(is-converted-subrule)> ast;
-			<debug> <collect-all(?SdfProductionWithCons(SortCons(SortDef(name), _), _, _) + ?SdfProduction(SortDef(name), _,_)); debug; not(?[_])> ast;
+			(name, cons) := <fetch-elem(is-converted-subrule)> ast;
+			<collect-all(?SdfProductionWithCons(SortCons(SortDef(name), _), _, _) + ?SdfProduction(SortDef(name), _,_)); not(?[_])> ast;
 			new_name := <string-replace(|"SR", "SubRule")> name;
 			new_ast := <try(remove-stupid)> <topdown(try((SortDef(name) -> SortDef(new_name)) + (Sort(name) -> Sort(new_name)) + (string-replace(|name, new_name))))> ast
 			
@@ -119,7 +115,6 @@ rules
 	is-converted-subrule:
 		SdfProductionWithCons(SortCons(SortDef(name), Constructor(cons)), elements, attr) -> (name, cons)
 		where
-			<debug> name;
 			<string-tokenize(|['-']); (fetch("SR")+fetch("KW"))>  name;
 			<not(equal)> (cons, name)
 			

--- a/nl.tudelft.xtext/trans/generate/restrictions.str
+++ b/nl.tudelft.xtext/trans/generate/restrictions.str
@@ -66,6 +66,9 @@ rules
   
   escape-lit: "'_'" -> "\\_"
   escape-lit: "' '" -> "\\ "
+  escape-lit: "'-'" -> "\\-"
+  escape-lit: "'.'" -> "\\."
+  escape-lit: "'$'" -> "\\$"
 
   // Remove redundant parentheticals
   remove-paren:


### PR DESCRIPTION
Minor fixes:
- removed debugging code
- escape extra characters when merging `CiLit` into `CharClass`
