### PR TITLE
Parse strings with escaped quotes

### DIFF
--- a/nl.tudelft.xtext/syntax/Common.sdf3
+++ b/nl.tudelft.xtext/syntax/Common.sdf3
@@ -6,10 +6,14 @@ lexical syntax
 	
 	STRING  	        = "\"" DoubleStringChar* "\""
 	STRING           	= "'" SingleStringChar* "'"
-	DoubleStringChars 	=  DoubleStringChar*
+	
+	DoubleStringChars =  DoubleStringChar*
 	DoubleStringChar 	= ~[\"\n]
-	SingleStringChars 	= SingleStringChar*
+	DoubleStringChar  = [\\][\"]
+	
+	SingleStringChars = SingleStringChar*
 	SingleStringChar 	= ~[\'\n] 
+	SingleStringChar  = [\\][\']
 	 
 	LAYOUT         = [\ \t\n\r] 
 	CommentChar    = [\*] 


### PR DESCRIPTION
Previously, this would not be parsed:

```
terminal X:
  '\'';
```

Now it is parsed and transformed into:

```
lexical syntax

  X = '\'' 
```

See also [here](http://homepages.cwi.nl/~daybuild/daily-books/syntax/2-sdf/sdf.html#section.Strings).
