### PR TITLE
Constructor fix

### DIFF
--- a/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
+++ b/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
@@ -47,7 +47,8 @@ rules
 		where
 			<string-tokenize(|['-']); fetch("SR")> cons;
 			keywords := <map(get-element)> elements;
-			new_cons := <concat-strings> keywords 
+			new_cons := <concat-strings> keywords;
+			<lt> (<string-length> new_cons, 25)
 	
 	get-element:
 		Label(_, element) -> <get-element-content> element
@@ -87,6 +88,7 @@ rules
 			<not(?[_] + ?[])> <collect-all(?SdfProductionWithCons(SortCons(SortDef(name), Constructor(cons)), _, _))> ast;
 			suffix := <map(get-element)> elements;
 			new_cons := <concat-strings> [cons| suffix];
+			<lt> (<string-length> new_cons, 25);
 			new_rule := SdfProductionWithCons(SortCons(SortDef(name), Constructor(new_cons)), e, attr)
 	
 	is-duplicated-sortcons(|ast):

--- a/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
+++ b/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
@@ -202,3 +202,17 @@ rules
 	to-alpha:
 		"]" -> "CloseBr"				
 	
+	//Functions to remove invalid and oversized constructor names
+	remove-invalid-sortcons:
+		a@SdfProductionWithCons(SortCons(SortDef(name), Constructor(cons)), e@Rhs(elements), attr) -> new-rule
+		where
+			<not(is-alphanum)> <explode-string> cons;
+			new-cons := <newname> "InvalidConstructor-";
+			new-rule := SdfProductionWithCons(SortCons(SortDef(name), Constructor(new-cons)), e, attr)
+	
+	remove-invalid-sortcons:
+		a@SdfProductionWithCons(SortCons(SortDef(name), Constructor(cons)), e@Rhs(elements), attr) -> new-rule
+		where
+			<gt>(<string-length> cons, <add>(<string-length> name, 15));
+			new-cons := <newname> "OversizedConstructor-";
+			new-rule := SdfProductionWithCons(SortCons(SortDef(name), Constructor(new-cons)), e, attr)

--- a/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
+++ b/nl.tudelft.xtext/trans/generate/generate-constructor-names.str
@@ -74,7 +74,7 @@ rules
 		Lit(quoted-word) -> output
 		where
 			word := <un-double-quote> quoted-word;
-			output := <first-to-uc> <to-alpha + is-alpha> word
+			output := <first-to-uc> <to-alpha + (explode-string; is-alpha)> word
 	
 	remove-duplicate-sortcons:
 		ast -> new_ast

--- a/nl.tudelft.xtext/trans/generate/post.str
+++ b/nl.tudelft.xtext/trans/generate/post.str
@@ -19,7 +19,7 @@ rules
     ])
     with
       cfs* := <collect(?ContextFreeSyntax(_))> sdf-sections;
-      cfs-productions := <nub> <try(remove-stupid)> <remove-duplicate-sortcons> <map(try(nested-complex-list))> <try(remove-stupid)> <map(try(add-missing-constructor))> <collect(?SdfProduction(_, _, _)+?SdfProductionWithCons(_,_,_))> cfs*;
+      cfs-productions := <map(try(remove-invalid-sortcons))> <nub> <try(remove-stupid)> <remove-duplicate-sortcons> <map(try(nested-complex-list))> <try(remove-stupid)> <map(try(add-missing-constructor))> <collect(?SdfProduction(_, _, _)+?SdfProductionWithCons(_,_,_))> cfs*;
 
       lex* := <collect(?LexicalSyntax(_))> sdf-sections;
       lex-productions := <nub> <filter(not(is-self-injection))> <collect(?SdfProduction(_, _, _))> lex*;


### PR DESCRIPTION
Added functionality to limit the size of constructor names, it is currently limited to +15 compared to the size of a sort (so long sorts allow for long constructors). It also removes invalid constructors that contain invalid characters
